### PR TITLE
Add monocular Lucid GigE camera support across ag-cam-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 CC      = gcc
 CXX     ?= g++
-CFLAGS  = -Wall -Wextra -O2 \
+# -MMD -MP emits per-object .d dependency files so headers (e.g. struct
+# layout in common.h) trigger rebuilds of every .c that includes them.
+# Without this, callers compiled against a stale struct size produced
+# silent stack overflows when AgCameraConfig grew.
+CFLAGS  = -Wall -Wextra -O2 -MMD -MP \
           $(shell pkg-config --cflags aravis-0.8) \
           $(shell pkg-config --cflags sdl2)
 LIBS    = $(shell pkg-config --libs aravis-0.8) \
@@ -106,6 +110,16 @@ ifneq ($(ONNXRT_LIBS),)
   SRCS   += $(SRCDIR)/stereo_onnx.c
 endif
 
+# --- FFmpeg: optional, provides video recording ---
+FFMPEG_CFLAGS := $(shell pkg-config --cflags libavcodec libavformat libavutil libswscale 2>/dev/null)
+FFMPEG_LIBS   := $(shell pkg-config --libs   libavcodec libavformat libavutil libswscale 2>/dev/null)
+
+ifneq ($(FFMPEG_LIBS),)
+  CFLAGS += $(FFMPEG_CFLAGS) -DHAVE_FFMPEG=1
+  LIBS   += $(FFMPEG_LIBS)
+  SRCS   += $(SRCDIR)/video_writer.c
+endif
+
 PREFIX     ?= /usr/local
 BASHCOMPDIR ?= $(PREFIX)/share/bash-completion/completions
 ZSHCOMPDIR  ?= $(PREFIX)/share/zsh/site-functions
@@ -142,6 +156,10 @@ $(APRILTAG_LIB): $(APRILTAG_OBJS)
 $(TARGET): $(OBJS) $(VENDOR_OBJS) $(CXX_OBJS) $(APRILTAG_LIB)
 	$(CC) -o $@ $(OBJS) $(VENDOR_OBJS) $(CXX_OBJS) $(if $(APRILTAG_LIB),-L$(BINDIR) -lapriltag) $(LIBS)
 	codesign --force --sign - $@ 2>/dev/null || true
+
+# Pull in header-dependency files emitted by -MMD/-MP.  Missing files
+# (first build) are ignored thanks to the leading dash.
+-include $(OBJS:.o=.d) $(VENDOR_OBJS:.o=.d) $(CXX_OBJS:.o=.d)
 
 install: $(TARGET)
 	install -d $(DESTDIR)$(PREFIX)/bin
@@ -281,6 +299,7 @@ test-hw: $(TARGET) $(BINDIR)/gen_test_calibration
 	$(TESTDIR)/test_capture_rectify_hw.sh
 	$(TESTDIR)/test_burst_hw.sh
 	$(TESTDIR)/test_bounce_hw.sh
+	$(TESTDIR)/test_record_hw.sh
 
 test-all: test test-hw
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # agrippa-stereocam
 
-Stereo camera toolkit for the [Lucid Phoenix PHD016S](https://thinklucid.com/product/phoenix-1-6mp-dual-head-model-imx273/) dual-head GigE Vision camera. It covers camera discovery, capture, live preview, focus alignment, calibration workflows, and classical or neural depth preview.
+Camera toolkit for Lucid GigE Vision cameras. The primary target is the [Lucid Phoenix PHD016S](https://thinklucid.com/product/phoenix-1-6mp-dual-head-model-imx273/) dual-head stereo camera, with monocular Lucid cameras (e.g. Triton TRT016S) supported for the non-stereo subcommands (`list`, `connect`, `stream`, single-shot `capture`). It covers camera discovery, capture, live preview, focus alignment, calibration workflows, and classical or neural depth preview.
+
+Sensor topology (stereo vs mono) is auto-detected at camera open by probing the device's available pixel formats — `DualBayerRG8` advertises stereo, anything else falls back to mono. Subcommands that intrinsically need two eyes (`depth-preview-*`, `depth-capture`, `focus`, `calibration-capture`, `--burst`) reject mono cameras with a clear error.
 
 Documentation now lives in the dedicated docs site:
 
@@ -91,7 +93,7 @@ source completions/ag-cam-tools.zsh
 
 ## Hardware snapshot
 
-Platform: [Lucid Phoenix PHD 1.6 MP Dual Extended-Head (IMX273)](https://thinklucid.com/product/phoenix-1-6mp-dual-head-model-imx273/)
+Primary platform: [Lucid Phoenix PHD 1.6 MP Dual Extended-Head (IMX273)](https://thinklucid.com/product/phoenix-1-6mp-dual-head-model-imx273/)
 
 | Parameter | Value |
 |-----------|-------|
@@ -101,6 +103,8 @@ Platform: [Lucid Phoenix PHD 1.6 MP Dual Extended-Head (IMX273)](https://thinklu
 | Pixel size | 3.45 um |
 | Interface | 1000BASE-T (GigE Vision) |
 | Power | PoE or 12-24 VDC |
+
+Also supported (non-stereo subcommands only): monocular Lucid GigE cameras such as the Triton TRT016S (1440 x 1080 single-sensor, BayerRG8). Detection is automatic via the camera's advertised pixel formats; if the model whitelist needs to take over for unusual firmware, see the implementation in `src/common.c:detect_sensor_mode`.
 
 Additional hardware notes live in [docs/hardware/circuits.md](docs/hardware/circuits.md).
 

--- a/docs/cli/calibration-capture.md
+++ b/docs/cli/calibration-capture.md
@@ -50,3 +50,13 @@ Within it, images are saved into:
 - Press `s` to save the current pair.
 - Press `q` or `Esc` to quit.
 - The window title shows the running image count.
+
+## Sensor modes
+
+`calibration-capture` is **stereo-only**. It produces the image pairs feeding a downstream stereo intrinsics + extrinsics calibration. Run against a monocular Lucid camera, it exits with:
+
+```
+error: calibration-capture is stereo-only; mono Lucid cameras need a single-camera intrinsics workflow that is not yet implemented
+```
+
+Single-camera intrinsic calibration for mono Lucid cameras is a candidate follow-up.

--- a/docs/cli/capture.md
+++ b/docs/cli/capture.md
@@ -76,6 +76,17 @@ Detection is compiled in when the `apriltag` library is available (system instal
 
 AprilTag detection is supported in both single-frame and `--burst` modes.
 
+## Sensor modes
+
+`capture` supports both stereo Lucid heads (PDH016S, DualBayerRG8) and monocular Lucid GigE cameras (Triton TRT016S, BayerRG8 / Mono8). Sensor mode is auto-detected at camera open.
+
+| Mode | Output filenames | `--burst` | `--calibration-*` | `--tag-size` |
+|------|------------------|-----------|-------------------|--------------|
+| stereo | `capture_<ts>_left.{pgm,png,jpg}` + `_right.*` | Supported | Supported | Detected per eye, overlays drawn into output |
+| mono | `capture_<ts>.{pgm,png,jpg}` (single image) | Rejected with error | Rejected with error | Detected on the single image, results logged only (no overlay rendered) |
+
+Mono burst capture and mono single-camera intrinsics rectification are tracked as follow-ups; today the tool fails fast with a clear error if those flags are used against a mono camera.
+
 ## Notes
 
 - `-A` is mutually exclusive with explicit `-x` and `-g`.

--- a/docs/cli/depth-capture.md
+++ b/docs/cli/depth-capture.md
@@ -55,6 +55,14 @@ Calibration is mandatory. Supply either `--calibration-local` or `--calibration-
 - Stereo rectification remap tables (for disparity computation).
 - `focal_length_px` and `baseline_cm` in the calibration metadata (for disparity-to-depth conversion).
 
+## Sensor modes
+
+`depth-capture` requires a **stereo** Lucid camera. Run against a monocular camera (e.g. Triton TRT016S), it exits immediately with non-zero status and:
+
+```
+error: depth-capture requires a stereo Lucid camera; detected monocular sensor on TRT016S-C (243000112)
+```
+
 ## Notes
 
 - The disparity backend is SGBM (classical). SGBM parameters are seeded from calibration metadata (`min_disparity`, `num_disparities`).

--- a/docs/cli/depth-preview-classical.md
+++ b/docs/cli/depth-preview-classical.md
@@ -93,6 +93,14 @@ When `--stereo-backend sgbm` is active, live tuning is available:
 | `9` / `0` | `mode` |
 | `p` | Print the current parameter set |
 
+## Sensor modes
+
+`depth-preview-classical` requires a **stereo** Lucid camera. Run against a monocular camera (e.g. Triton TRT016S), it exits immediately with non-zero status and:
+
+```
+error: depth-preview requires a stereo Lucid camera; detected monocular sensor on TRT016S-C (243000112)
+```
+
 ## Notes
 
 - When the camera reports that post-binning data is no longer Bayer, the image is fed to the disparity pipeline as grayscale directly, skipping debayering.

--- a/docs/cli/depth-preview-neural.md
+++ b/docs/cli/depth-preview-neural.md
@@ -18,6 +18,10 @@ ag-cam-tools depth-preview-neural -a 192.168.0.201 -A --calibration-slot 0 --ste
 
 The CLI also accepts `igev` and `foundation` as aliases for `onnx`.
 
+## Sensor modes
+
+`depth-preview-neural` requires a **stereo** Lucid camera. The mono refusal behavior matches `depth-preview-classical` — see that page for the exact error message.
+
 ## Notes
 
 - `depth-preview-neural` uses the same major CLI options as `depth-preview-classical`.

--- a/docs/cli/focus.md
+++ b/docs/cli/focus.md
@@ -72,3 +72,13 @@ By default the command also emits procedural stereo audio:
 - once focus is considered aligned, alternating confirmation beeps are played.
 
 The detailed audio design is documented in [../workflows/focus-audio.md](../workflows/focus-audio.md).
+
+## Sensor modes
+
+`focus` is **stereo-only**. Its core function is comparing left vs right focus scores to indicate which eye to adjust; this has no analogue on a single sensor. Run against a monocular Lucid camera (e.g. Triton TRT016S), it exits immediately with:
+
+```
+error: focus is stereo-only (compares left vs right focus scores); not yet implemented for mono cameras
+```
+
+A single-camera focus mode is a candidate follow-up.

--- a/docs/cli/list.md
+++ b/docs/cli/list.md
@@ -1,6 +1,6 @@
 # `list`
 
-Discover and print GigE cameras visible on the network.
+Discover and print GigE cameras visible on the network, annotated with detected stereo / mono sensor mode.
 
 ## Examples
 
@@ -8,10 +8,24 @@ Discover and print GigE cameras visible on the network.
 ag-cam-tools list
 ag-cam-tools list --machine-readable
 ag-cam-tools list -i en0
+ag-cam-tools list --no-probe
 ```
+
+## Sensor mode column
+
+For each enumerated camera the tool briefly opens the device and probes available pixel formats:
+
+| Value | Meaning |
+|-------|---------|
+| `stereo` | Advertises `DualBayerRG8` (Lucid PDH016S and similar dual-eye heads) |
+| `mono` | Advertises `BayerRG8` / `Mono8` only (Lucid Triton TRT016S etc.) |
+| `unknown` | Could not open the device, has no usable 8-bit pixel format, or `--no-probe` was set |
+
+Probe failures are non-fatal — the row is still printed with `mode=unknown`.
 
 ## Notes
 
 - The default output is an ASCII table.
-- `--machine-readable` emits tab-separated output for scripts.
+- `--machine-readable` emits tab-separated output (4 fields: ip, model, serial, mode) for scripts.
+- `--no-probe` skips the per-camera open. Useful when cameras are in use elsewhere or when enumeration latency matters; all rows show `mode=unknown`.
 - Use `-i` when multiple network interfaces are present and discovery picks the wrong one.

--- a/docs/cli/stream.md
+++ b/docs/cli/stream.md
@@ -39,6 +39,17 @@ Supplying `--calibration-local` or `--calibration-slot` enables stereo rectifica
 
 On ARM64 platforms, the remap path uses NEON acceleration.
 
+## Sensor modes
+
+`stream` supports both stereo Lucid heads (e.g. PDH016S, DualBayerRG8) and monocular Lucid GigE cameras (e.g. Triton TRT016S, BayerRG8 / Mono8). The mode is auto-detected at camera open by probing the device's available pixel formats — `DualBayerRG8` advertises stereo, anything else falls back to mono.
+
+| Mode | Window title | Recording | Rectification |
+|------|--------------|-----------|---------------|
+| stereo | `Stereo Stream` | Side-by-side / top-bottom / separate per `--record-layout` | Supported via `--calibration-*` |
+| mono | `Mono Stream` | Single-frame MP4 (mono layout, ignores `--record-layout`) | Not supported — calibration flags rejected |
+
+When `--record-layout` is set on a mono camera, a warning is printed and the recording falls back to mono layout. AprilTag detection runs on the single image instead of left/right eyes.
+
 ## Notes
 
 - Press `q` or `Esc` to quit.

--- a/src/cmd_calibration_capture.c
+++ b/src/cmd_calibration_capture.c
@@ -115,6 +115,20 @@ calibration_capture_loop (const char *device_id, const char *iface_ip,
         return EXIT_FAILURE;
     }
 
+    /* calibration-capture produces a stereo intrinsics + extrinsics
+     * pair; mono single-camera intrinsic calibration is a different
+     * workflow not implemented here. */
+    if (cfg.sensor_mode == AG_SENSOR_MONO) {
+        fprintf (stderr,
+                 "error: calibration-capture is stereo-only; mono Lucid "
+                 "cameras need a single-camera intrinsics workflow that "
+                 "is not yet implemented\n");
+        g_object_unref (cfg.stream);
+        g_object_unref (camera);
+        arv_shutdown ();
+        return EXIT_FAILURE;
+    }
+
     ArvDevice *device = arv_camera_get_device (camera);
 
     /* Query the camera serial number for the session folder name. */

--- a/src/cmd_capture.c
+++ b/src/cmd_capture.c
@@ -1,9 +1,11 @@
 /*
  * cmd_capture.c — "ag-cam-tools capture" subcommand
  *
- * SingleFrame acquisition with software trigger.  Writes DualBayerRG8
- * stereo pairs to disk.  With --burst N, captures N frames in rapid
- * succession via FrameBurstStart triggering.
+ * SingleFrame acquisition with software trigger.  Writes a stereo
+ * DualBayerRG8 pair (PDH016S) or a single Bayer/Mono frame (mono
+ * Lucid cameras like the Triton TRT016S).  With --burst N, captures N
+ * frames in rapid succession via FrameBurstStart triggering — burst is
+ * currently stereo-only.
  */
 
 #include "common.h"
@@ -51,11 +53,22 @@ capture_one_frame (const char *device_id, const char *output_dir,
 
     ArvDevice *device = arv_camera_get_device (camera);
 
-    /* Load rectification remap tables if calibration was requested. */
+    /* Load rectification remap tables if calibration was requested.
+     * Rectification requires a stereo calibration pipeline; mono
+     * cameras have nothing meaningful to rectify here. */
     AgRemapTable *remap_left  = NULL;
     AgRemapTable *remap_right = NULL;
 
     if (calib_src->local_path || calib_src->slot >= 0) {
+        if (cfg.sensor_mode == AG_SENSOR_MONO) {
+            fprintf (stderr,
+                     "error: --calibration-local / --calibration-slot are "
+                     "stereo-only; not applicable to mono cameras\n");
+            g_object_unref (cfg.stream);
+            g_object_unref (camera);
+            arv_shutdown ();
+            return EXIT_FAILURE;
+        }
         if (ag_calib_load (device, calib_src,
                             &remap_left, &remap_right, NULL) != 0) {
             g_object_unref (cfg.stream);
@@ -283,6 +296,25 @@ capture_one_frame (const char *device_id, const char *output_dir,
                                         ov_left, n_ltags,
                                         ov_right, n_rtags);
         } else {
+#ifdef HAVE_APRILTAG
+            /* Mono path: optional tag detection.  Tags are logged via
+             * ag_detect_tags_and_pose; overlay rendering into the saved
+             * image is not yet implemented for mono. */
+            if (tag_size_m > 0.0) {
+                guint sub_w = width  / (guint) cfg.software_binning;
+                guint sub_h = height / (guint) cfg.software_binning;
+                AgApriltagContext *at_ctx = ag_apriltag_create ();
+                double fx, fy, cx, cy;
+                ag_apriltag_estimate_intrinsics (sub_w, sub_h,
+                                                 &fx, &fy, &cx, &cy);
+                AgTagOverlay tags[AG_MAX_TAG_OVERLAYS];
+                ag_detect_tags_and_pose (at_ctx->detector, data,
+                                         sub_w, sub_h, tag_size_m,
+                                         fx, fy, cx, cy, 0, "mono",
+                                         tags, AG_MAX_TAG_OVERLAYS, FALSE);
+                ag_apriltag_destroy (at_ctx);
+            }
+#endif
             const char *ext = (enc == AG_ENC_PNG) ? "png"
                             : (enc == AG_ENC_JPG) ? "jpg" : "pgm";
             char *name = g_strdup_printf ("%s.%s", base, ext);
@@ -291,6 +323,8 @@ capture_one_frame (const char *device_id, const char *output_dir,
                 rc = write_pgm (path, data, width, height);
             else
                 rc = write_color_image (enc, path, data, width, height);
+            printf ("Saved: %s  (%ux%u, %s)\n", path, width, height,
+                    pixel_format ? pixel_format : "?");
             g_free (name);
             g_free (path);
         }
@@ -336,6 +370,18 @@ capture_burst_frames (const char *device_id, const char *output_dir,
     if (camera_configure (camera, AG_MODE_CONTINUOUS,
                           binning, exposure_us, gain_db, auto_expose,
                           packet_size, iface_ip, verbose, &cfg) != EXIT_SUCCESS) {
+        g_object_unref (camera);
+        arv_shutdown ();
+        return EXIT_FAILURE;
+    }
+
+    /* Burst capture currently writes via write_dual_bayer_pair, which
+     * is stereo-only.  Mono burst would need a separate pipeline. */
+    if (cfg.sensor_mode == AG_SENSOR_MONO) {
+        fprintf (stderr,
+                 "error: --burst is currently stereo-only; not yet "
+                 "implemented for mono cameras\n");
+        g_object_unref (cfg.stream);
         g_object_unref (camera);
         arv_shutdown ();
         return EXIT_FAILURE;

--- a/src/cmd_depth_capture.c
+++ b/src/cmd_depth_capture.c
@@ -53,6 +53,22 @@ depth_capture (const char *device_id, const char *output_dir,
         return EXIT_FAILURE;
     }
 
+    /* Stereo depth requires two eyes; refuse mono cameras explicitly. */
+    if (cfg.sensor_mode == AG_SENSOR_MONO) {
+        const char *model  = arv_camera_get_model_name (camera, NULL);
+        const char *serial = arv_device_get_string_feature_value (
+            arv_camera_get_device (camera), "DeviceSerialNumber", NULL);
+        fprintf (stderr,
+                 "error: depth-capture requires a stereo Lucid camera; "
+                 "detected monocular sensor on %s (%s)\n",
+                 model  ? model  : "(unknown model)",
+                 serial ? serial : "(unknown serial)");
+        g_object_unref (cfg.stream);
+        g_object_unref (camera);
+        arv_shutdown ();
+        return EXIT_FAILURE;
+    }
+
     ArvDevice *device = arv_camera_get_device (camera);
 
     /* Processing dimensions (per eye). */

--- a/src/cmd_depth_preview.c
+++ b/src/cmd_depth_preview.c
@@ -180,6 +180,23 @@ depth_preview_loop (const char *device_id, const char *iface_ip,
         return EXIT_FAILURE;
     }
 
+    /* Stereo depth requires two eyes; refuse mono cameras explicitly
+     * rather than producing nonsense or crashing downstream. */
+    if (cfg.sensor_mode == AG_SENSOR_MONO) {
+        const char *model  = arv_camera_get_model_name (camera, NULL);
+        const char *serial = arv_device_get_string_feature_value (
+            arv_camera_get_device (camera), "DeviceSerialNumber", NULL);
+        fprintf (stderr,
+                 "error: depth-preview requires a stereo Lucid camera; "
+                 "detected monocular sensor on %s (%s)\n",
+                 model  ? model  : "(unknown model)",
+                 serial ? serial : "(unknown serial)");
+        g_object_unref (cfg.stream);
+        g_object_unref (camera);
+        arv_shutdown ();
+        return EXIT_FAILURE;
+    }
+
     ArvDevice *device = arv_camera_get_device (camera);
 
     /* Compute processing dimensions. */

--- a/src/cmd_focus.c
+++ b/src/cmd_focus.c
@@ -77,6 +77,19 @@ focus_loop (const char *device_id, const char *iface_ip,
         return EXIT_FAILURE;
     }
 
+    /* The focus subcommand's value comes from comparing left/right scores
+     * to indicate which eye to adjust.  Mono single-eye focus would need
+     * a different UX and is not implemented here. */
+    if (cfg.sensor_mode == AG_SENSOR_MONO) {
+        fprintf (stderr,
+                 "error: focus is stereo-only (compares left vs right "
+                 "focus scores); not yet implemented for mono cameras\n");
+        g_object_unref (cfg.stream);
+        g_object_unref (camera);
+        arv_shutdown ();
+        return EXIT_FAILURE;
+    }
+
     ArvDevice *device = arv_camera_get_device (camera);
 
     /* Compute display dimensions. */

--- a/src/cmd_list.c
+++ b/src/cmd_list.c
@@ -8,12 +8,52 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 typedef struct {
     const char *ip;
     const char *model;
     const char *serial;
+    const char *mode;     /* "stereo", "mono", or "unknown" */
 } CameraRow;
+
+/* Briefly open the device to probe stereo vs mono.  Returns "stereo",
+ * "mono", or "unknown" on failure (e.g. device in use, no usable
+ * pixel format, transport error).  Silences detect_sensor_mode's
+ * stderr complaints since "unknown" already conveys the outcome and
+ * non-Lucid GigE cameras (3D scanners etc.) routinely fail this
+ * probe. */
+static const char *
+probe_sensor_mode (const char *device_id)
+{
+    GError *error = NULL;
+    ArvCamera *camera = arv_camera_new (device_id, &error);
+    if (!camera || error) {
+        g_clear_error (&error);
+        if (camera) g_object_unref (camera);
+        return "unknown";
+    }
+
+    int saved_stderr = dup (fileno (stderr));
+    FILE *devnull = fopen ("/dev/null", "w");
+    if (devnull)
+        dup2 (fileno (devnull), fileno (stderr));
+
+    AgSensorMode mode;
+    int rc = detect_sensor_mode (camera, &mode, NULL, 0);
+
+    fflush (stderr);
+    if (devnull) {
+        dup2 (saved_stderr, fileno (stderr));
+        fclose (devnull);
+    }
+    close (saved_stderr);
+
+    g_object_unref (camera);
+    if (rc != 0)
+        return "unknown";
+    return (mode == AG_SENSOR_STEREO) ? "stereo" : "mono";
+}
 
 static gboolean
 is_gige_protocol (const char *protocol)
@@ -25,7 +65,7 @@ is_gige_protocol (const char *protocol)
 }
 
 static void
-print_separator (size_t ip_w, size_t model_w, size_t serial_w)
+print_separator (size_t ip_w, size_t model_w, size_t serial_w, size_t mode_w)
 {
     printf ("+");
     for (size_t i = 0; i < ip_w + 2; i++) printf ("-");
@@ -33,6 +73,8 @@ print_separator (size_t ip_w, size_t model_w, size_t serial_w)
     for (size_t i = 0; i < model_w + 2; i++) printf ("-");
     printf ("+");
     for (size_t i = 0; i < serial_w + 2; i++) printf ("-");
+    printf ("+");
+    for (size_t i = 0; i < mode_w + 2; i++) printf ("-");
     printf ("+\n");
 }
 
@@ -46,9 +88,11 @@ cmd_list (int argc, char *argv[], arg_dstr_t res, void *ctx)
                                           "restrict to this NIC");
     struct arg_lit *machine   = arg_lit0 (NULL, "machine-readable",
                                           "tab-separated output for completions");
+    struct arg_lit *no_probe  = arg_lit0 (NULL, "no-probe",
+                                          "skip per-camera open (mode=unknown)");
     struct arg_lit *help      = arg_lit0 ("h", "help", "print this help");
     struct arg_end *end       = arg_end (5);
-    void *argtable[] = { cmd, interface, machine, help, end };
+    void *argtable[] = { cmd, interface, machine, no_probe, help, end };
 
     int exitcode = EXIT_SUCCESS;
     if (arg_nullcheck (argtable) != 0) {
@@ -88,6 +132,7 @@ cmd_list (int argc, char *argv[], arg_dstr_t res, void *ctx)
     size_t ip_w     = strlen ("IP");
     size_t model_w  = strlen ("MODEL");
     size_t serial_w = strlen ("SERIAL");
+    size_t mode_w   = strlen ("MODE");
 
     for (guint i = 0; i < n; i++) {
         const char *protocol = arv_get_device_protocol (i);
@@ -103,13 +148,18 @@ cmd_list (int argc, char *argv[], arg_dstr_t res, void *ctx)
         rows[row_count].ip     = ip     ? ip     : "(unknown)";
         rows[row_count].model  = model_s  ? model_s  : "(unknown)";
         rows[row_count].serial = serial_s ? serial_s : "(unknown)";
+        rows[row_count].mode   = no_probe->count
+                                 ? "unknown"
+                                 : probe_sensor_mode (arv_get_device_id (i));
 
         size_t ip_len     = strlen (rows[row_count].ip);
         size_t model_len  = strlen (rows[row_count].model);
         size_t serial_len = strlen (rows[row_count].serial);
+        size_t mode_len   = strlen (rows[row_count].mode);
         if (ip_len     > ip_w)     ip_w     = ip_len;
         if (model_len  > model_w)  model_w  = model_len;
         if (serial_len > serial_w) serial_w = serial_len;
+        if (mode_len   > mode_w)   mode_w   = mode_len;
 
         row_count++;
     }
@@ -117,24 +167,27 @@ cmd_list (int argc, char *argv[], arg_dstr_t res, void *ctx)
     if (machine->count) {
         /* Tab-separated, no headers — for shell completions. */
         for (guint i = 0; i < row_count; i++)
-            printf ("%s\t%s\t%s\n", rows[i].ip, rows[i].model, rows[i].serial);
+            printf ("%s\t%s\t%s\t%s\n",
+                    rows[i].ip, rows[i].model, rows[i].serial, rows[i].mode);
     } else {
         printf ("GigE cameras: %u\n", row_count);
 
-        print_separator (ip_w, model_w, serial_w);
-        printf ("| %-*s | %-*s | %-*s |\n",
+        print_separator (ip_w, model_w, serial_w, mode_w);
+        printf ("| %-*s | %-*s | %-*s | %-*s |\n",
                 (int) ip_w, "IP",
                 (int) model_w, "MODEL",
-                (int) serial_w, "SERIAL");
-        print_separator (ip_w, model_w, serial_w);
+                (int) serial_w, "SERIAL",
+                (int) mode_w, "MODE");
+        print_separator (ip_w, model_w, serial_w, mode_w);
 
         for (guint i = 0; i < row_count; i++)
-            printf ("| %-*s | %-*s | %-*s |\n",
+            printf ("| %-*s | %-*s | %-*s | %-*s |\n",
                     (int) ip_w, rows[i].ip,
                     (int) model_w, rows[i].model,
-                    (int) serial_w, rows[i].serial);
+                    (int) serial_w, rows[i].serial,
+                    (int) mode_w, rows[i].mode);
 
-        print_separator (ip_w, model_w, serial_w);
+        print_separator (ip_w, model_w, serial_w, mode_w);
     }
 
     g_free (rows);

--- a/src/cmd_stream.c
+++ b/src/cmd_stream.c
@@ -1,9 +1,11 @@
 /*
  * cmd_stream.c — "ag-cam-tools stream" subcommand
  *
- * Continuously captures DualBayerRG8 frames, debayers each eye,
- * and displays them side-by-side in an SDL2 window.
- * Optionally detects AprilTags and estimates their pose.
+ * Continuously captures frames from a Lucid GigE camera and displays
+ * them in an SDL2 window.  For stereo Lucid heads (DualBayerRG8) the
+ * two eyes are split and rendered side-by-side; for monocular cameras
+ * (BayerRG8 / Mono8) a single frame fills the window.  Optionally
+ * detects AprilTags and estimates their pose.
  */
 
 #include "common.h"
@@ -11,12 +13,16 @@
 #include "calib_load.h"
 #include "font.h"
 #include "remap.h"
+#ifdef HAVE_FFMPEG
+#include "video_writer.h"
+#endif
 #include "../vendor/argtable3.h"
 
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include <SDL2/SDL.h>
 
@@ -33,7 +39,9 @@ static int
 stream_loop (const char *device_id, const char *iface_ip,
              double fps, double exposure_us, double gain_db,
              gboolean auto_expose, int packet_size, int binning,
-             double tag_size_m, const AgCalibSource *calib_src)
+             double tag_size_m, const AgCalibSource *calib_src,
+             const char *output_dir, int record_layout,
+             gboolean record_layout_user_set)
 {
     GError *error = NULL;
     ArvCamera *camera = arv_camera_new (device_id, &error);
@@ -57,13 +65,15 @@ stream_loop (const char *device_id, const char *iface_ip,
     }
 
     ArvDevice *device = arv_camera_get_device (camera);
+    const gboolean is_mono = (cfg.sensor_mode == AG_SENSOR_MONO);
 
-    /* Compute display dimensions. */
-    guint src_sub_w  = cfg.frame_w / 2;
+    /* Compute display dimensions.  Stereo splits the incoming frame in
+     * half; mono uses it whole. */
+    guint src_sub_w  = is_mono ? cfg.frame_w : cfg.frame_w / 2;
     guint src_h      = cfg.frame_h;
     guint proc_sub_w = src_sub_w / (guint) cfg.software_binning;
     guint proc_h     = src_h     / (guint) cfg.software_binning;
-    guint display_w  = proc_sub_w * 2;
+    guint display_w  = is_mono ? proc_sub_w : proc_sub_w * 2;
     guint display_h  = proc_h;
 
 #ifdef HAVE_APRILTAG
@@ -78,8 +88,10 @@ stream_loop (const char *device_id, const char *iface_ip,
         ag_apriltag_estimate_intrinsics (proc_sub_w, proc_h,
                                          &at_fx, &at_fy, &at_cx, &at_cy);
 
-        tracker_left  = ag_tag_tracker_create ("left",  5.0, 0.01, 10);
-        tracker_right = ag_tag_tracker_create ("right", 5.0, 0.01, 10);
+        tracker_left  = ag_tag_tracker_create (is_mono ? "mono" : "left",
+                                                5.0, 0.01, 10);
+        if (!is_mono)
+            tracker_right = ag_tag_tracker_create ("right", 5.0, 0.01, 10);
 
         printf ("AprilTag: tagStandard52h13 + tagStandard41h12, "
                 "tag_size=%.3f m, fx=%.1f fy=%.1f cx=%.1f cy=%.1f\n",
@@ -99,7 +111,7 @@ stream_loop (const char *device_id, const char *iface_ip,
     }
 
     SDL_Window *window = SDL_CreateWindow (
-        "Stereo Stream",
+        is_mono ? "Mono Stream" : "Stereo Stream",
         SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
         (int) display_w, (int) display_h,
         SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
@@ -140,19 +152,29 @@ stream_loop (const char *device_id, const char *iface_ip,
         return EXIT_FAILURE;
     }
 
-    /* Scratch buffers. */
+    /* Scratch buffers.  In mono mode the _right buffers stay NULL. */
     guint8 *rgb_left        = g_malloc ((size_t) proc_sub_w * proc_h * 3);
-    guint8 *rgb_right       = g_malloc ((size_t) proc_sub_w * proc_h * 3);
+    guint8 *rgb_right       = is_mono ? NULL :
+                              g_malloc ((size_t) proc_sub_w * proc_h * 3);
     guint8 *bayer_left      = g_malloc ((size_t) proc_sub_w * proc_h);
-    guint8 *bayer_right     = g_malloc ((size_t) proc_sub_w * proc_h);
+    guint8 *bayer_right     = is_mono ? NULL :
+                              g_malloc ((size_t) proc_sub_w * proc_h);
 
-    /* Load rectification remap tables (optional). */
+    /* Load rectification remap tables (optional, stereo only).  Mono
+     * single-camera undistortion would need a different calibration
+     * pipeline and is not currently implemented. */
     AgRemapTable *remap_left  = NULL;
     AgRemapTable *remap_right = NULL;
     guint8 *rect_left  = NULL;
     guint8 *rect_right = NULL;
 
     if (calib_src->local_path || calib_src->slot >= 0) {
+        if (is_mono) {
+            fprintf (stderr,
+                     "error: --calibration-local / --calibration-slot are "
+                     "stereo-only; not applicable to mono cameras\n");
+            goto cleanup;
+        }
         if (ag_calib_load (device, calib_src,
                             &remap_left, &remap_right, NULL) != 0)
             goto cleanup;
@@ -173,7 +195,38 @@ stream_loop (const char *device_id, const char *iface_ip,
 
     /* Pointers used for SDL upload — either raw or rectified. */
     const guint8 *display_left  = remap_left ? rect_left  : rgb_left;
-    const guint8 *display_right = remap_left ? rect_right : rgb_right;
+    const guint8 *display_right = is_mono ? NULL :
+                                  (remap_left ? rect_right : rgb_right);
+
+#ifdef HAVE_FFMPEG
+    /* Video recording.  Mono cameras force MONO layout regardless of
+     * --record-layout. */
+    AgVideoWriter *video_writer = NULL;
+    if (output_dir) {
+        time_t now = time (NULL);
+        struct tm *tm = localtime (&now);
+        char ts[32];
+        strftime (ts, sizeof ts, "%Y%m%d_%H%M%S", tm);
+        char mp4_path[1024];
+        snprintf (mp4_path, sizeof mp4_path, "%s/stream_%s.mp4",
+                  output_dir, ts);
+        AgVideoLayout layout = is_mono ? AG_VIDEO_LAYOUT_MONO
+                                       : (AgVideoLayout) record_layout;
+        if (is_mono && record_layout_user_set)
+            fprintf (stderr,
+                     "warning: --record-layout is stereo-only; using mono "
+                     "layout for this single-sensor camera\n");
+        video_writer = ag_video_writer_new (mp4_path, (int) proc_sub_w,
+                                             (int) proc_h, fps, layout);
+        if (!video_writer) {
+            fprintf (stderr, "warning: could not open video writer, "
+                     "continuing without recording\n");
+        }
+    }
+#else
+    (void) output_dir;
+    (void) record_layout;
+#endif
 
     /* Start acquisition. */
     printf ("Starting acquisition at %.1f Hz...\n", fps);
@@ -260,18 +313,26 @@ stream_loop (const char *device_id, const char *iface_ip,
         guint h = arv_buffer_get_image_height (buffer);
         size_t needed = (size_t) w * (size_t) h;
 
-        if (!data || data_size < needed || w % 2 != 0 ||
-            w != cfg.frame_w || h != cfg.frame_h) {
+        gboolean geom_ok = (w == cfg.frame_w && h == cfg.frame_h);
+        if (!is_mono && (w % 2 != 0))
+            geom_ok = FALSE;
+        if (!data || data_size < needed || !geom_ok) {
             frames_dropped++;
             arv_stream_push_buffer (cfg.stream, buffer);
             continue;
         }
 
-        extract_dual_bayer_eyes (data, w, h, cfg.software_binning,
-                                 bayer_left, bayer_right);
+        if (is_mono) {
+            /* Mono: copy the full Bayer/Mono frame directly. */
+            memcpy (bayer_left, data, (size_t) proc_sub_w * proc_h);
+        } else {
+            extract_dual_bayer_eyes (data, w, h, cfg.software_binning,
+                                     bayer_left, bayer_right);
+        }
 
 #ifdef HAVE_APRILTAG
-        /* Detect tags on raw grayscale (before gamma), both eyes. */
+        /* Detect tags on raw grayscale (before gamma).  Mono uses one
+         * detector; stereo runs both eyes through. */
         int n_left_tags = 0, n_right_tags = 0;
         AgTagOverlay left_tags[AG_MAX_TAG_OVERLAYS];
         AgTagOverlay right_tags[AG_MAX_TAG_OVERLAYS];
@@ -280,32 +341,37 @@ stream_loop (const char *device_id, const char *iface_ip,
                 at_ctx->detector, bayer_left,
                 proc_sub_w, proc_h, tag_size_m,
                 at_fx, at_fy, at_cx, at_cy,
-                total_frames, "left",
+                total_frames, is_mono ? "mono" : "left",
                 left_tags, AG_MAX_TAG_OVERLAYS, TRUE);
-            n_right_tags = ag_detect_tags_and_pose (
-                at_ctx->detector, bayer_right,
-                proc_sub_w, proc_h, tag_size_m,
-                at_fx, at_fy, at_cx, at_cy,
-                total_frames, "right",
-                right_tags, AG_MAX_TAG_OVERLAYS, TRUE);
-
             ag_tag_tracker_update (tracker_left,  left_tags,  n_left_tags,  total_frames);
-            ag_tag_tracker_update (tracker_right, right_tags, n_right_tags, total_frames);
             ag_tag_tracker_check_disappeared (tracker_left,  total_frames);
-            ag_tag_tracker_check_disappeared (tracker_right, total_frames);
+
+            if (!is_mono) {
+                n_right_tags = ag_detect_tags_and_pose (
+                    at_ctx->detector, bayer_right,
+                    proc_sub_w, proc_h, tag_size_m,
+                    at_fx, at_fy, at_cx, at_cy,
+                    total_frames, "right",
+                    right_tags, AG_MAX_TAG_OVERLAYS, TRUE);
+                ag_tag_tracker_update (tracker_right, right_tags, n_right_tags, total_frames);
+                ag_tag_tracker_check_disappeared (tracker_right, total_frames);
+            }
         }
 #endif
 
         size_t eye_n = (size_t) proc_sub_w * (size_t) proc_h;
         apply_lut_inplace (bayer_left,  eye_n, gamma_lut);
-        apply_lut_inplace (bayer_right, eye_n, gamma_lut);
+        if (!is_mono)
+            apply_lut_inplace (bayer_right, eye_n, gamma_lut);
 
         if (cfg.data_is_bayer) {
             debayer_rg8_to_rgb (bayer_left,  rgb_left,  proc_sub_w, proc_h);
-            debayer_rg8_to_rgb (bayer_right, rgb_right, proc_sub_w, proc_h);
+            if (!is_mono)
+                debayer_rg8_to_rgb (bayer_right, rgb_right, proc_sub_w, proc_h);
         } else {
             gray_to_rgb_replicate (bayer_left,  rgb_left,  (uint32_t) eye_n);
-            gray_to_rgb_replicate (bayer_right, rgb_right, (uint32_t) eye_n);
+            if (!is_mono)
+                gray_to_rgb_replicate (bayer_right, rgb_right, (uint32_t) eye_n);
         }
 
         if (remap_left) {
@@ -317,22 +383,50 @@ stream_loop (const char *device_id, const char *iface_ip,
         void *tex_pixels;
         int tex_pitch;
         if (SDL_LockTexture (texture, NULL, &tex_pixels, &tex_pitch) == 0) {
-            for (guint y = 0; y < proc_h; y++) {
-                guint8 *dst = (guint8 *) tex_pixels + (size_t) y * (size_t) tex_pitch;
-                memcpy (dst,
-                        display_left + (size_t) y * proc_sub_w * 3,
-                        proc_sub_w * 3);
-                memcpy (dst + proc_sub_w * 3,
-                        display_right + (size_t) y * proc_sub_w * 3,
-                        proc_sub_w * 3);
+            if (is_mono) {
+                for (guint y = 0; y < proc_h; y++) {
+                    guint8 *dst = (guint8 *) tex_pixels + (size_t) y * (size_t) tex_pitch;
+                    memcpy (dst,
+                            display_left + (size_t) y * proc_sub_w * 3,
+                            proc_sub_w * 3);
+                }
+            } else {
+                for (guint y = 0; y < proc_h; y++) {
+                    guint8 *dst = (guint8 *) tex_pixels + (size_t) y * (size_t) tex_pitch;
+                    memcpy (dst,
+                            display_left + (size_t) y * proc_sub_w * 3,
+                            proc_sub_w * 3);
+                    memcpy (dst + proc_sub_w * 3,
+                            display_right + (size_t) y * proc_sub_w * 3,
+                            proc_sub_w * 3);
+                }
             }
             SDL_UnlockTexture (texture);
         }
+
+#ifdef HAVE_FFMPEG
+        if (video_writer) {
+            if (is_mono)
+                ag_video_writer_add_mono_frame (video_writer, display_left);
+            else
+                ag_video_writer_add_frame (video_writer, display_left,
+                                            display_right);
+        }
+#endif
 
         arv_stream_push_buffer (cfg.stream, buffer);
 
         SDL_RenderClear (renderer);
         SDL_RenderCopy (renderer, texture, NULL, NULL);
+
+#ifdef HAVE_FFMPEG
+        /* REC indicator overlay. */
+        if (video_writer) {
+            int out_w, out_h;
+            SDL_GetRendererOutputSize (renderer, &out_w, &out_h);
+            ag_font_render (renderer, "REC", out_w - 60, 10, 2, 255, 40, 40);
+        }
+#endif
 
 #ifdef HAVE_APRILTAG
         /* Draw detected tag outlines as quadrilaterals with ID labels.
@@ -364,21 +458,23 @@ stream_loop (const char *device_id, const char *iface_ip,
                 ag_font_render (renderer, label, lx, ly, 2, 0, 255, 0);
             }
 
-            for (int t = 0; t < n_right_tags; t++) {
-                double x_off = (double) proc_sub_w;
-                for (int c = 0; c < 4; c++) {
-                    int nc = (c + 1) % 4;
-                    SDL_RenderDrawLine (renderer,
-                        (int) ((right_tags[t].p[c][0]  + x_off) * sx),
-                        (int) ( right_tags[t].p[c][1]           * sy),
-                        (int) ((right_tags[t].p[nc][0] + x_off) * sx),
-                        (int) ( right_tags[t].p[nc][1]          * sy));
+            if (!is_mono) {
+                for (int t = 0; t < n_right_tags; t++) {
+                    double x_off = (double) proc_sub_w;
+                    for (int c = 0; c < 4; c++) {
+                        int nc = (c + 1) % 4;
+                        SDL_RenderDrawLine (renderer,
+                            (int) ((right_tags[t].p[c][0]  + x_off) * sx),
+                            (int) ( right_tags[t].p[c][1]           * sy),
+                            (int) ((right_tags[t].p[nc][0] + x_off) * sx),
+                            (int) ( right_tags[t].p[nc][1]          * sy));
+                    }
+                    char label[16];
+                    snprintf (label, sizeof label, "%d", right_tags[t].id);
+                    int lx = (int) ((right_tags[t].center[0] + x_off) * sx);
+                    int ly = (int) (right_tags[t].center[1] * sy) - 16;
+                    ag_font_render (renderer, label, lx, ly, 2, 0, 255, 0);
                 }
-                char label[16];
-                snprintf (label, sizeof label, "%d", right_tags[t].id);
-                int lx = (int) ((right_tags[t].center[0] + x_off) * sx);
-                int ly = (int) (right_tags[t].center[1] * sy) - 16;
-                ag_font_render (renderer, label, lx, ly, 2, 0, 255, 0);
             }
         }
 #endif
@@ -404,6 +500,10 @@ stream_loop (const char *device_id, const char *iface_ip,
     g_timer_destroy (stats_timer);
     printf ("\nStopping...\n");
     arv_camera_stop_acquisition (camera, NULL);
+
+#ifdef HAVE_FFMPEG
+    ag_video_writer_close (video_writer);
+#endif
 
 cleanup:
     g_free (rect_left);
@@ -459,13 +559,17 @@ cmd_stream (int argc, char *argv[], arg_dstr_t res, void *ctx)
                                             "rectify using on-camera calibration slot");
     struct arg_dbl *tag_size  = arg_dbl0 ("t", "tag-size",  "<meters>",
                                           "AprilTag size in meters (enables detection)");
+    struct arg_str *output    = arg_str0 ("o", "output",   "<dir>",
+                                          "record session to MP4 in <dir>");
+    struct arg_str *rec_layout = arg_str0 (NULL, "record-layout", "<sbs|tb|separate>",
+                                           "stereo layout for recording (default: sbs)");
     struct arg_lit *help      = arg_lit0 ("h", "help", "print this help");
     struct arg_end *end       = arg_end (10);
 
     void *argtable[] = { cmd, serial, address, interface, fps_a, exposure,
                          gain, auto_exp, binning_a, pkt_size,
                          calib_local, calib_slot,
-                         tag_size, help, end };
+                         tag_size, output, rec_layout, help, end };
 
     int exitcode = EXIT_SUCCESS;
     if (arg_nullcheck (argtable) != 0) {
@@ -559,6 +663,33 @@ cmd_stream (int argc, char *argv[], arg_dstr_t res, void *ctx)
         printf ("Rectification enabled (calibration from camera slot %d).\n",
                 calib_src.slot);
 
+    /* Video recording options. */
+    const char *output_dir = output->count ? output->sval[0] : NULL;
+    int rl = 0;  /* AG_VIDEO_LAYOUT_SBS */
+#ifdef HAVE_FFMPEG
+    if (rec_layout->count) {
+        AgVideoLayout vl;
+        if (ag_video_layout_parse (rec_layout->sval[0], &vl) != 0) {
+            arg_dstr_catf (res, "error: unrecognised --record-layout '%s' "
+                           "(use sbs, tb, or separate)\n",
+                           rec_layout->sval[0]);
+            exitcode = EXIT_FAILURE;
+            goto done;
+        }
+        rl = (int) vl;
+    }
+    if (output_dir && !output->count) {
+        /* unreachable, but silences warning */
+    }
+#else
+    if (output_dir)
+        fprintf (stderr,
+                 "warning: -o/--output ignored (compiled without FFmpeg support)\n");
+    if (rec_layout->count)
+        fprintf (stderr,
+                 "warning: --record-layout ignored (compiled without FFmpeg support)\n");
+#endif
+
     double tag_size_m = 0.0;
 #ifdef HAVE_APRILTAG
     if (tag_size->count) {
@@ -593,7 +724,8 @@ cmd_stream (int argc, char *argv[], arg_dstr_t res, void *ctx)
 
     exitcode = stream_loop (device_id, iface_ip, fps, exposure_us, gain_db,
                             do_auto_expose, pkt_sz, binning, tag_size_m,
-                            &calib_src);
+                            &calib_src, output_dir, rl,
+                            rec_layout->count > 0);
     g_free (device_id);
 
 done:

--- a/src/common.c
+++ b/src/common.c
@@ -441,15 +441,15 @@ camera_configure (ArvCamera *camera, AgAcquisitionMode mode,
     try_set_string_feature  (device, "TriggerSource", "Software");
     try_set_string_feature  (device, "ImagerOutputSelector", "All");
 
-    /* Detect stereo vs mono and pick the matching pixel format BEFORE
-     * geometry, since WidthMax/HeightMax depend on the active format. */
+    /* Probe sensor topology now (read-only).  PixelFormat is written
+     * later, after binning and geometry, to preserve the historical
+     * setup ordering known to work on Lucid firmware. */
     if (detect_sensor_mode (camera, &out->sensor_mode,
                             out->pixel_format, sizeof out->pixel_format) != 0)
         return EXIT_FAILURE;
     printf ("  sensor_mode = %s (PixelFormat=%s)\n",
             out->sensor_mode == AG_SENSOR_STEREO ? "stereo" : "mono",
             out->pixel_format);
-    try_set_string_feature (device, "PixelFormat", out->pixel_format);
 
     /* Binning. */
     try_set_string_feature  (device, "BinningSelector",       "Sensor");
@@ -473,30 +473,37 @@ camera_configure (ArvCamera *camera, AgAcquisitionMode mode,
                  eff_bin_h, eff_bin_v, out->software_binning);
     }
 
-    /* Geometry.  Query WidthMax/HeightMax post-binning rather than using
-     * the PDH016S constants, so mono cameras (single-sensor) and any
-     * future variants pick up the correct full-frame dimensions. */
+    /* Geometry.  Stereo cameras use the historical PDH016S constants
+     * (preserves exact behavior on the production camera).  Mono cameras
+     * query WidthMax/HeightMax since their physical sensor size is
+     * different from the stereo head and unknown at compile time. */
     try_set_integer_feature (device, "OffsetX", 0);
     try_set_integer_feature (device, "OffsetY", 0);
 
-    gint64 width_max  = read_integer_feature_or_default (device, "WidthMax",
-        (eff_bin_h > 0 ? AG_SENSOR_WIDTH  / eff_bin_h : AG_SENSOR_WIDTH));
-    gint64 height_max = read_integer_feature_or_default (device, "HeightMax",
-        (eff_bin_v > 0 ? AG_SENSOR_HEIGHT / eff_bin_v : AG_SENSOR_HEIGHT));
+    gint64 target_w, target_h;
+    if (out->sensor_mode == AG_SENSOR_STEREO) {
+        target_w = (eff_bin_h > 0) ? (AG_SENSOR_WIDTH  / eff_bin_h) : AG_SENSOR_WIDTH;
+        target_h = (eff_bin_v > 0) ? (AG_SENSOR_HEIGHT / eff_bin_v) : AG_SENSOR_HEIGHT;
+    } else {
+        target_w = read_integer_feature_or_default (device, "WidthMax",  AG_SENSOR_WIDTH);
+        target_h = read_integer_feature_or_default (device, "HeightMax", AG_SENSOR_HEIGHT);
+    }
 
-    try_set_integer_feature (device, "Width",  width_max);
-    try_set_integer_feature (device, "Height", height_max);
+    try_set_integer_feature (device, "Width",  target_w);
+    try_set_integer_feature (device, "Height", target_h);
 
-    gint64 width_rb  = read_integer_feature_or_default (device, "Width",  width_max);
-    gint64 height_rb = read_integer_feature_or_default (device, "Height", height_max);
-    if (width_rb != width_max || height_rb != height_max) {
+    gint64 width_rb  = read_integer_feature_or_default (device, "Width",  target_w);
+    gint64 height_rb = read_integer_feature_or_default (device, "Height", target_h);
+    if (width_rb != target_w || height_rb != target_h) {
         fprintf (stderr,
                  "warn: geometry readback is %" G_GINT64_FORMAT "x%" G_GINT64_FORMAT
                  " (requested %" G_GINT64_FORMAT "x%" G_GINT64_FORMAT ")\n",
-                 width_rb, height_rb, width_max, height_max);
+                 width_rb, height_rb, target_w, target_h);
     }
     out->frame_w = (guint) width_rb;
     out->frame_h = (guint) height_rb;
+
+    try_set_string_feature (device, "PixelFormat", out->pixel_format);
 
     /* Determine whether post-processing should treat data as Bayer.
      *

--- a/src/common.c
+++ b/src/common.c
@@ -338,6 +338,75 @@ try_execute_optional_command (ArvDevice *device, const char *name)
 }
 
 /* ================================================================== */
+/*  Sensor-mode detection                                             */
+/* ================================================================== */
+
+int
+detect_sensor_mode (ArvCamera *camera, AgSensorMode *out_mode,
+                    char *out_pixel_format, size_t buf_len)
+{
+    if (!camera || !out_mode)
+        return -1;
+
+    GError *error = NULL;
+    guint n = 0;
+    const char **formats =
+        arv_camera_dup_available_pixel_formats_as_strings (camera, &n, &error);
+    if (error || !formats) {
+        if (error) {
+            fprintf (stderr, "warn: failed to query pixel formats: %s\n",
+                     error->message);
+            g_clear_error (&error);
+        }
+        g_free (formats);
+        return -1;
+    }
+
+    /* Stereo if DualBayerRG8 is in the available list.  Mono otherwise:
+     * pick BayerRG8, then any other BayerRG variant, then Mono8.  This
+     * priority matches the imgproc debayer path (BayerRG) and avoids
+     * silently picking a 16-bit format that downstream cannot handle. */
+    const char *stereo_fmt = NULL;
+    const char *mono_fmt   = NULL;
+    const char *fallback   = NULL;
+
+    for (guint i = 0; i < n; i++) {
+        const char *fmt = formats[i];
+        if (!fmt)
+            continue;
+        if (g_strcmp0 (fmt, "DualBayerRG8") == 0) {
+            stereo_fmt = fmt;
+            break;
+        }
+        if (!mono_fmt && g_strcmp0 (fmt, "BayerRG8") == 0)
+            mono_fmt = fmt;
+        else if (!fallback && g_strcmp0 (fmt, "Mono8") == 0)
+            fallback = fmt;
+    }
+
+    const char *chosen = stereo_fmt ? stereo_fmt :
+                         (mono_fmt  ? mono_fmt  : fallback);
+    if (!chosen) {
+        fprintf (stderr, "error: camera advertises no supported 8-bit "
+                 "pixel format (need DualBayerRG8, BayerRG8, or Mono8); "
+                 "advertised: ");
+        for (guint i = 0; i < n; i++)
+            fprintf (stderr, "%s%s", formats[i] ? formats[i] : "?",
+                     (i + 1 < n) ? ", " : "");
+        fprintf (stderr, "\n");
+        g_free (formats);
+        return -1;
+    }
+
+    *out_mode = stereo_fmt ? AG_SENSOR_STEREO : AG_SENSOR_MONO;
+    if (out_pixel_format && buf_len > 0)
+        g_strlcpy (out_pixel_format, chosen, buf_len);
+
+    g_free (formats);
+    return 0;
+}
+
+/* ================================================================== */
 /*  Unified camera configuration                                      */
 /* ================================================================== */
 
@@ -372,6 +441,16 @@ camera_configure (ArvCamera *camera, AgAcquisitionMode mode,
     try_set_string_feature  (device, "TriggerSource", "Software");
     try_set_string_feature  (device, "ImagerOutputSelector", "All");
 
+    /* Detect stereo vs mono and pick the matching pixel format BEFORE
+     * geometry, since WidthMax/HeightMax depend on the active format. */
+    if (detect_sensor_mode (camera, &out->sensor_mode,
+                            out->pixel_format, sizeof out->pixel_format) != 0)
+        return EXIT_FAILURE;
+    printf ("  sensor_mode = %s (PixelFormat=%s)\n",
+            out->sensor_mode == AG_SENSOR_STEREO ? "stereo" : "mono",
+            out->pixel_format);
+    try_set_string_feature (device, "PixelFormat", out->pixel_format);
+
     /* Binning. */
     try_set_string_feature  (device, "BinningSelector",       "Sensor");
     try_set_integer_feature (device, "BinningHorizontal",     (gint64) binning);
@@ -394,26 +473,30 @@ camera_configure (ArvCamera *camera, AgAcquisitionMode mode,
                  eff_bin_h, eff_bin_v, out->software_binning);
     }
 
-    /* Geometry. */
+    /* Geometry.  Query WidthMax/HeightMax post-binning rather than using
+     * the PDH016S constants, so mono cameras (single-sensor) and any
+     * future variants pick up the correct full-frame dimensions. */
     try_set_integer_feature (device, "OffsetX", 0);
     try_set_integer_feature (device, "OffsetY", 0);
-    gint64 target_w = (eff_bin_h > 0) ? (AG_SENSOR_WIDTH  / eff_bin_h) : AG_SENSOR_WIDTH;
-    gint64 target_h = (eff_bin_v > 0) ? (AG_SENSOR_HEIGHT / eff_bin_v) : AG_SENSOR_HEIGHT;
-    try_set_integer_feature (device, "Width",  target_w);
-    try_set_integer_feature (device, "Height", target_h);
 
-    gint64 width_rb  = read_integer_feature_or_default (device, "Width",  target_w);
-    gint64 height_rb = read_integer_feature_or_default (device, "Height", target_h);
-    if (width_rb != target_w || height_rb != target_h) {
+    gint64 width_max  = read_integer_feature_or_default (device, "WidthMax",
+        (eff_bin_h > 0 ? AG_SENSOR_WIDTH  / eff_bin_h : AG_SENSOR_WIDTH));
+    gint64 height_max = read_integer_feature_or_default (device, "HeightMax",
+        (eff_bin_v > 0 ? AG_SENSOR_HEIGHT / eff_bin_v : AG_SENSOR_HEIGHT));
+
+    try_set_integer_feature (device, "Width",  width_max);
+    try_set_integer_feature (device, "Height", height_max);
+
+    gint64 width_rb  = read_integer_feature_or_default (device, "Width",  width_max);
+    gint64 height_rb = read_integer_feature_or_default (device, "Height", height_max);
+    if (width_rb != width_max || height_rb != height_max) {
         fprintf (stderr,
                  "warn: geometry readback is %" G_GINT64_FORMAT "x%" G_GINT64_FORMAT
                  " (requested %" G_GINT64_FORMAT "x%" G_GINT64_FORMAT ")\n",
-                 width_rb, height_rb, target_w, target_h);
+                 width_rb, height_rb, width_max, height_max);
     }
     out->frame_w = (guint) width_rb;
     out->frame_h = (guint) height_rb;
-
-    try_set_string_feature (device, "PixelFormat", "DualBayerRG8");
 
     /* Determine whether post-processing should treat data as Bayer.
      *

--- a/src/common.h
+++ b/src/common.h
@@ -18,7 +18,9 @@ typedef struct {
     double baseline_cm;
 } AgCalibMeta;
 
-/* Sensor geometry for the PDH016S (DualBayerRG8). */
+/* Default (fallback) sensor geometry for the PDH016S (DualBayerRG8 dual-eye).
+ * Used only if the camera's WidthMax/HeightMax cannot be queried.  Real
+ * geometry is taken from the device on every open. */
 #define AG_SENSOR_WIDTH   2880
 #define AG_SENSOR_HEIGHT  1080
 
@@ -28,14 +30,24 @@ typedef enum {
     AG_MODE_CONTINUOUS
 } AgAcquisitionMode;
 
+/* Sensor topology detected on camera open.  STEREO means a dual-eye
+ * Lucid head delivering DualBayerRG8 (left+right interleaved per row);
+ * MONO means a single-sensor camera delivering BayerRG8 or Mono8. */
+typedef enum {
+    AG_SENSOR_STEREO,
+    AG_SENSOR_MONO
+} AgSensorMode;
+
 /* Returned by camera_configure(). */
 typedef struct {
-    ArvStream *stream;
-    guint      frame_w;          /* width after binning  */
-    guint      frame_h;          /* height after binning */
-    int        software_binning; /* >1 if HW binning unavailable */
-    size_t     payload;
-    gboolean   data_is_bayer;    /* FALSE when eff. binning > 1 */
+    ArvStream   *stream;
+    guint        frame_w;          /* width after binning  */
+    guint        frame_h;          /* height after binning */
+    int          software_binning; /* >1 if HW binning unavailable */
+    size_t       payload;
+    gboolean     data_is_bayer;    /* FALSE when eff. binning > 1 */
+    AgSensorMode sensor_mode;      /* stereo dual-eye vs single sensor */
+    char         pixel_format[32]; /* actual PixelFormat selected      */
 } AgCameraConfig;
 
 /* --- Network helpers --- */
@@ -76,6 +88,17 @@ gboolean try_get_integer_feature (ArvDevice *dev, const char *name,
 gboolean try_get_float_feature   (ArvDevice *dev, const char *name,
                                   double *out_value);
 void     try_execute_optional_command (ArvDevice *dev, const char *name);
+
+/*
+ * Probe an opened camera's available pixel formats and decide whether it
+ * is a stereo Lucid head (advertises DualBayerRG8) or a monocular Lucid
+ * camera (BayerRG8 / Mono8 only).  On success, *out_mode is set and
+ * *out_pixel_format is filled with the recommended PixelFormat string
+ * (caller-provided buffer, recommend >= 32 bytes).  Returns 0 on
+ * success, -1 if no usable pixel format is available.
+ */
+int detect_sensor_mode (ArvCamera *camera, AgSensorMode *out_mode,
+                        char *out_pixel_format, size_t buf_len);
 
 /* --- Unified camera configuration --- */
 

--- a/src/video_writer.c
+++ b/src/video_writer.c
@@ -1,0 +1,538 @@
+/*
+ * video_writer.c — MP4 video recording for ag-cam-tools
+ *
+ * Wraps FFmpeg libavcodec / libavformat / libswscale to encode
+ * RGB24 stereo frame pairs into H.264 MP4 files.
+ */
+
+#include "video_writer.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/opt.h>
+#include <libswscale/swscale.h>
+
+/* ------------------------------------------------------------------------ */
+/*  Single-stream encoder state                                              */
+/* ------------------------------------------------------------------------ */
+
+typedef struct {
+    AVFormatContext *fmt_ctx;
+    AVCodecContext  *codec_ctx;
+    AVStream        *stream;
+    struct SwsContext *sws;
+    AVFrame         *frame;     /* YUV420P working frame */
+    AVPacket        *pkt;
+    int64_t          pts;
+} AgEncoder;
+
+/* ------------------------------------------------------------------------ */
+/*  Writer                                                                   */
+/* ------------------------------------------------------------------------ */
+
+struct AgVideoWriter {
+    AgVideoLayout layout;
+    int           eye_w;
+    int           eye_h;
+    int64_t       frame_count;
+
+    /* Assembly buffer for SBS / TB compositing (pre-allocated). */
+    uint8_t      *composite_buf;
+    int           composite_w;
+    int           composite_h;
+
+    /* One encoder for SBS / TB, two for SEPARATE. */
+    AgEncoder     enc[2];
+    int           n_encoders;
+};
+
+/* ------------------------------------------------------------------------ */
+/*  Layout parsing                                                           */
+/* ------------------------------------------------------------------------ */
+
+int
+ag_video_layout_parse (const char *str, AgVideoLayout *out)
+{
+    if (!str || !out) return -1;
+    if (strcmp (str, "sbs") == 0 || strcmp (str, "side-by-side") == 0)
+        { *out = AG_VIDEO_LAYOUT_SBS; return 0; }
+    if (strcmp (str, "tb") == 0 || strcmp (str, "top-bottom") == 0)
+        { *out = AG_VIDEO_LAYOUT_TOP_BOTTOM; return 0; }
+    if (strcmp (str, "separate") == 0)
+        { *out = AG_VIDEO_LAYOUT_SEPARATE; return 0; }
+    if (strcmp (str, "mono") == 0)
+        { *out = AG_VIDEO_LAYOUT_MONO; return 0; }
+    return -1;
+}
+
+/* ------------------------------------------------------------------------ */
+/*  Encoder helpers                                                          */
+/* ------------------------------------------------------------------------ */
+
+static const AVCodec *
+find_h264_encoder (void)
+{
+#ifdef __APPLE__
+    const AVCodec *vtb = avcodec_find_encoder_by_name ("h264_videotoolbox");
+    if (vtb) return vtb;
+#endif
+    return avcodec_find_encoder (AV_CODEC_ID_H264);
+}
+
+/* Round width/height up to even (H.264 requires even dimensions). */
+static int
+round_even (int v)
+{
+    return (v + 1) & ~1;
+}
+
+static int
+encoder_open (AgEncoder *enc, const char *path, int width, int height,
+              double fps, const AVCodec *codec)
+{
+    int ret;
+
+    memset (enc, 0, sizeof *enc);
+
+    /* Output format context. */
+    ret = avformat_alloc_output_context2 (&enc->fmt_ctx, NULL, NULL, path);
+    if (ret < 0 || !enc->fmt_ctx) {
+        fprintf (stderr, "error: could not create output context for %s\n",
+                 path);
+        return -1;
+    }
+
+    /* Stream. */
+    enc->stream = avformat_new_stream (enc->fmt_ctx, NULL);
+    if (!enc->stream) {
+        fprintf (stderr, "error: could not create video stream\n");
+        goto fail;
+    }
+
+    /* Codec context. */
+    enc->codec_ctx = avcodec_alloc_context3 (codec);
+    if (!enc->codec_ctx) {
+        fprintf (stderr, "error: could not allocate codec context\n");
+        goto fail;
+    }
+
+    enc->codec_ctx->width     = width;
+    enc->codec_ctx->height    = height;
+    enc->codec_ctx->pix_fmt   = AV_PIX_FMT_YUV420P;
+    enc->codec_ctx->time_base = (AVRational){ 1, (int) (fps * 1000) };
+    enc->stream->time_base    = enc->codec_ctx->time_base;
+
+    /* Try to hint for quality. CRF-like for software x264, bitrate for HW. */
+    if (strcmp (codec->name, "h264_videotoolbox") == 0) {
+        /* VideoToolbox: use a reasonable constant-quality bitrate. */
+        enc->codec_ctx->bit_rate = (int64_t) width * height * 4;
+        av_opt_set (enc->codec_ctx->priv_data, "realtime", "true", 0);
+    } else {
+        /* Software x264: CRF 18. */
+        av_opt_set (enc->codec_ctx->priv_data, "crf", "18", 0);
+        av_opt_set (enc->codec_ctx->priv_data, "preset", "fast", 0);
+    }
+
+    if (enc->fmt_ctx->oformat->flags & AVFMT_GLOBALHEADER)
+        enc->codec_ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+    ret = avcodec_open2 (enc->codec_ctx, codec, NULL);
+    if (ret < 0) {
+        fprintf (stderr, "error: could not open codec %s: %d\n",
+                 codec->name, ret);
+        goto fail;
+    }
+
+    ret = avcodec_parameters_from_context (enc->stream->codecpar,
+                                            enc->codec_ctx);
+    if (ret < 0) {
+        fprintf (stderr, "error: could not copy codec parameters\n");
+        goto fail;
+    }
+
+    /* Color-space converter: RGB24 → YUV420P. */
+    enc->sws = sws_getContext (width, height, AV_PIX_FMT_RGB24,
+                               width, height, AV_PIX_FMT_YUV420P,
+                               SWS_BILINEAR, NULL, NULL, NULL);
+    if (!enc->sws) {
+        fprintf (stderr, "error: could not create sws context\n");
+        goto fail;
+    }
+
+    /* Working frame. */
+    enc->frame = av_frame_alloc ();
+    if (!enc->frame) goto fail;
+    enc->frame->format = AV_PIX_FMT_YUV420P;
+    enc->frame->width  = width;
+    enc->frame->height = height;
+    ret = av_frame_get_buffer (enc->frame, 0);
+    if (ret < 0) {
+        fprintf (stderr, "error: could not allocate frame buffer\n");
+        goto fail;
+    }
+
+    enc->pkt = av_packet_alloc ();
+    if (!enc->pkt) goto fail;
+
+    /* Open output file. */
+    if (!(enc->fmt_ctx->oformat->flags & AVFMT_NOFILE)) {
+        ret = avio_open (&enc->fmt_ctx->pb, path, AVIO_FLAG_WRITE);
+        if (ret < 0) {
+            fprintf (stderr, "error: could not open output file %s\n", path);
+            goto fail;
+        }
+    }
+
+    ret = avformat_write_header (enc->fmt_ctx, NULL);
+    if (ret < 0) {
+        fprintf (stderr, "error: could not write header to %s\n", path);
+        goto fail;
+    }
+
+    enc->pts = 0;
+    return 0;
+
+fail:
+    if (enc->pkt) av_packet_free (&enc->pkt);
+    if (enc->frame) av_frame_free (&enc->frame);
+    if (enc->sws) sws_freeContext (enc->sws);
+    if (enc->codec_ctx) avcodec_free_context (&enc->codec_ctx);
+    if (enc->fmt_ctx) {
+        if (enc->fmt_ctx->pb &&
+            !(enc->fmt_ctx->oformat->flags & AVFMT_NOFILE))
+            avio_closep (&enc->fmt_ctx->pb);
+        avformat_free_context (enc->fmt_ctx);
+    }
+    memset (enc, 0, sizeof *enc);
+    return -1;
+}
+
+static int
+encoder_write_rgb (AgEncoder *enc, const uint8_t *rgb, int width,
+                   double fps)
+{
+    int ret;
+
+    ret = av_frame_make_writable (enc->frame);
+    if (ret < 0) return -1;
+
+    /* Convert RGB24 → YUV420P. */
+    const uint8_t *src_data[1] = { rgb };
+    int src_linesize[1]        = { width * 3 };
+    sws_scale (enc->sws, src_data, src_linesize, 0,
+               enc->frame->height, enc->frame->data,
+               enc->frame->linesize);
+
+    enc->frame->pts = enc->pts;
+    enc->pts += (int) (fps * 1000.0 / fps);  /* = 1000 per frame */
+
+    /* Encode. */
+    ret = avcodec_send_frame (enc->codec_ctx, enc->frame);
+    if (ret < 0) return -1;
+
+    while (ret >= 0) {
+        ret = avcodec_receive_packet (enc->codec_ctx, enc->pkt);
+        if (ret == AVERROR (EAGAIN) || ret == AVERROR_EOF)
+            break;
+        if (ret < 0) return -1;
+
+        av_packet_rescale_ts (enc->pkt, enc->codec_ctx->time_base,
+                              enc->stream->time_base);
+        enc->pkt->stream_index = enc->stream->index;
+
+        ret = av_interleaved_write_frame (enc->fmt_ctx, enc->pkt);
+        if (ret < 0) return -1;
+    }
+
+    return 0;
+}
+
+static int
+encoder_flush (AgEncoder *enc)
+{
+    int ret;
+
+    if (!enc->fmt_ctx) return 0;
+
+    /* Send NULL frame to flush. */
+    ret = avcodec_send_frame (enc->codec_ctx, NULL);
+    if (ret < 0 && ret != AVERROR_EOF) return -1;
+
+    while (1) {
+        ret = avcodec_receive_packet (enc->codec_ctx, enc->pkt);
+        if (ret == AVERROR_EOF || ret == AVERROR (EAGAIN))
+            break;
+        if (ret < 0) return -1;
+
+        av_packet_rescale_ts (enc->pkt, enc->codec_ctx->time_base,
+                              enc->stream->time_base);
+        enc->pkt->stream_index = enc->stream->index;
+        av_interleaved_write_frame (enc->fmt_ctx, enc->pkt);
+    }
+
+    return av_write_trailer (enc->fmt_ctx);
+}
+
+static void
+encoder_free (AgEncoder *enc)
+{
+    if (!enc->fmt_ctx) return;
+
+    if (enc->pkt) av_packet_free (&enc->pkt);
+    if (enc->frame) av_frame_free (&enc->frame);
+    if (enc->sws) sws_freeContext (enc->sws);
+    if (enc->codec_ctx) avcodec_free_context (&enc->codec_ctx);
+
+    if (enc->fmt_ctx->pb &&
+        !(enc->fmt_ctx->oformat->flags & AVFMT_NOFILE))
+        avio_closep (&enc->fmt_ctx->pb);
+    avformat_free_context (enc->fmt_ctx);
+    memset (enc, 0, sizeof *enc);
+}
+
+/* ------------------------------------------------------------------------ */
+/*  Path helpers for SEPARATE layout                                         */
+/* ------------------------------------------------------------------------ */
+
+static char *
+make_separate_path (const char *path, const char *suffix)
+{
+    /* Insert suffix before extension: "/dir/foo.mp4" → "/dir/foo_left.mp4" */
+    const char *dot = strrchr (path, '.');
+    size_t stem_len = dot ? (size_t)(dot - path) : strlen (path);
+    const char *ext = dot ? dot : ".mp4";
+    size_t suf_len  = strlen (suffix);
+    size_t ext_len  = strlen (ext);
+
+    char *out = malloc (stem_len + suf_len + ext_len + 1);
+    if (!out) return NULL;
+    memcpy (out, path, stem_len);
+    memcpy (out + stem_len, suffix, suf_len);
+    memcpy (out + stem_len + suf_len, ext, ext_len);
+    out[stem_len + suf_len + ext_len] = '\0';
+    return out;
+}
+
+/* ------------------------------------------------------------------------ */
+/*  Public API                                                               */
+/* ------------------------------------------------------------------------ */
+
+AgVideoWriter *
+ag_video_writer_new (const char *path, int eye_w, int eye_h,
+                      double fps, AgVideoLayout layout)
+{
+    const AVCodec *codec = find_h264_encoder ();
+    if (!codec) {
+        fprintf (stderr, "error: no H.264 encoder available\n");
+        return NULL;
+    }
+
+    AgVideoWriter *w = calloc (1, sizeof *w);
+    if (!w) return NULL;
+
+    w->layout  = layout;
+    w->eye_w   = eye_w;
+    w->eye_h   = eye_h;
+
+    switch (layout) {
+    case AG_VIDEO_LAYOUT_SBS:
+        w->composite_w = round_even (eye_w * 2);
+        w->composite_h = round_even (eye_h);
+        w->n_encoders  = 1;
+        break;
+    case AG_VIDEO_LAYOUT_TOP_BOTTOM:
+        w->composite_w = round_even (eye_w);
+        w->composite_h = round_even (eye_h * 2);
+        w->n_encoders  = 1;
+        break;
+    case AG_VIDEO_LAYOUT_SEPARATE:
+        w->composite_w = round_even (eye_w);
+        w->composite_h = round_even (eye_h);
+        w->n_encoders  = 2;
+        break;
+    case AG_VIDEO_LAYOUT_MONO:
+        w->composite_w = round_even (eye_w);
+        w->composite_h = round_even (eye_h);
+        w->n_encoders  = 1;
+        break;
+    }
+
+    /* Composite assembly buffer is only needed for SBS / TB compositing.
+     * SEPARATE and MONO encode their inputs directly. */
+    if (layout == AG_VIDEO_LAYOUT_SBS ||
+        layout == AG_VIDEO_LAYOUT_TOP_BOTTOM) {
+        w->composite_buf = malloc ((size_t) w->composite_w *
+                                   w->composite_h * 3);
+        if (!w->composite_buf) {
+            free (w);
+            return NULL;
+        }
+    }
+
+    /* Open encoder(s). */
+    if (layout == AG_VIDEO_LAYOUT_SEPARATE) {
+        char *left_path  = make_separate_path (path, "_left");
+        char *right_path = make_separate_path (path, "_right");
+        if (!left_path || !right_path) {
+            free (left_path);
+            free (right_path);
+            free (w);
+            return NULL;
+        }
+        int ok = 0;
+        ok |= encoder_open (&w->enc[0], left_path, w->composite_w,
+                             w->composite_h, fps, codec);
+        if (ok == 0)
+            ok |= encoder_open (&w->enc[1], right_path, w->composite_w,
+                                 w->composite_h, fps, codec);
+        free (left_path);
+        free (right_path);
+        if (ok != 0) {
+            encoder_free (&w->enc[0]);
+            encoder_free (&w->enc[1]);
+            free (w);
+            return NULL;
+        }
+    } else {
+        if (encoder_open (&w->enc[0], path, w->composite_w,
+                          w->composite_h, fps, codec) != 0) {
+            free (w->composite_buf);
+            free (w);
+            return NULL;
+        }
+    }
+
+    const char *layout_name =
+        layout == AG_VIDEO_LAYOUT_SBS        ? "sbs"        :
+        layout == AG_VIDEO_LAYOUT_TOP_BOTTOM ? "top-bottom" :
+        layout == AG_VIDEO_LAYOUT_SEPARATE   ? "separate"   :
+        layout == AG_VIDEO_LAYOUT_MONO       ? "mono"       : "?";
+
+    printf ("Recording to %s (%dx%d, %s, %.1f fps, codec %s)\n",
+            path, w->composite_w, w->composite_h, layout_name,
+            fps, codec->name);
+
+    return w;
+}
+
+int
+ag_video_writer_add_frame (AgVideoWriter *w,
+                            const uint8_t *left_rgb,
+                            const uint8_t *right_rgb)
+{
+    if (!w) return -1;
+
+    int ret = 0;
+    double fps = 1.0;  /* pts increment is fixed at 1000 in encoder */
+
+    switch (w->layout) {
+    case AG_VIDEO_LAYOUT_SBS: {
+        /* Copy left and right side by side into composite buffer. */
+        int ew3 = w->eye_w * 3;
+        int cw3 = w->composite_w * 3;
+        for (int y = 0; y < w->eye_h; y++) {
+            memcpy (w->composite_buf + y * cw3,
+                    left_rgb + y * ew3, ew3);
+            memcpy (w->composite_buf + y * cw3 + ew3,
+                    right_rgb + y * ew3, ew3);
+        }
+        /* Zero-fill padding columns if composite_w > eye_w * 2. */
+        if (w->composite_w > w->eye_w * 2) {
+            int pad = (w->composite_w - w->eye_w * 2) * 3;
+            for (int y = 0; y < w->eye_h; y++)
+                memset (w->composite_buf + y * cw3 + w->eye_w * 2 * 3,
+                        0, pad);
+        }
+        /* Zero-fill padding rows if composite_h > eye_h. */
+        for (int y = w->eye_h; y < w->composite_h; y++)
+            memset (w->composite_buf + y * cw3, 0, cw3);
+
+        ret = encoder_write_rgb (&w->enc[0], w->composite_buf,
+                                 w->composite_w, fps);
+        break;
+    }
+    case AG_VIDEO_LAYOUT_TOP_BOTTOM: {
+        /* Copy left on top, right on bottom. */
+        int ew3 = w->eye_w * 3;
+        int cw3 = w->composite_w * 3;
+        for (int y = 0; y < w->eye_h; y++) {
+            memcpy (w->composite_buf + y * cw3,
+                    left_rgb + y * ew3, ew3);
+            /* Zero-fill horizontal padding if any. */
+            if (w->composite_w > w->eye_w)
+                memset (w->composite_buf + y * cw3 + ew3, 0,
+                        (w->composite_w - w->eye_w) * 3);
+        }
+        for (int y = 0; y < w->eye_h; y++) {
+            memcpy (w->composite_buf + (w->eye_h + y) * cw3,
+                    right_rgb + y * ew3, ew3);
+            if (w->composite_w > w->eye_w)
+                memset (w->composite_buf + (w->eye_h + y) * cw3 + ew3, 0,
+                        (w->composite_w - w->eye_w) * 3);
+        }
+        /* Zero-fill padding rows at bottom. */
+        for (int y = w->eye_h * 2; y < w->composite_h; y++)
+            memset (w->composite_buf + y * cw3, 0, cw3);
+
+        ret = encoder_write_rgb (&w->enc[0], w->composite_buf,
+                                 w->composite_w, fps);
+        break;
+    }
+    case AG_VIDEO_LAYOUT_SEPARATE:
+        ret  = encoder_write_rgb (&w->enc[0], left_rgb, w->composite_w, fps);
+        ret |= encoder_write_rgb (&w->enc[1], right_rgb, w->composite_w, fps);
+        break;
+    case AG_VIDEO_LAYOUT_MONO:
+        /* Stereo entry point on a mono writer is a programming error. */
+        return -1;
+    }
+
+    if (ret == 0)
+        w->frame_count++;
+
+    return ret;
+}
+
+int
+ag_video_writer_add_mono_frame (AgVideoWriter *w, const uint8_t *rgb)
+{
+    if (!w || !rgb) return -1;
+    if (w->layout != AG_VIDEO_LAYOUT_MONO) return -1;
+
+    int ret = encoder_write_rgb (&w->enc[0], rgb, w->composite_w, 1.0);
+    if (ret == 0)
+        w->frame_count++;
+    return ret;
+}
+
+int64_t
+ag_video_writer_close (AgVideoWriter *w)
+{
+    if (!w) return 0;
+
+    int64_t count = w->frame_count;
+    int flush_err = 0;
+
+    for (int i = 0; i < w->n_encoders; i++) {
+        if (encoder_flush (&w->enc[i]) < 0)
+            flush_err = 1;
+        encoder_free (&w->enc[i]);
+    }
+
+    free (w->composite_buf);
+    free (w);
+
+    if (flush_err) {
+        fprintf (stderr, "warning: error flushing video encoder\n");
+        return -1;
+    }
+
+    printf ("Recording finished (%lld frames written).\n",
+            (long long) count);
+    return count;
+}

--- a/src/video_writer.h
+++ b/src/video_writer.h
@@ -1,0 +1,71 @@
+/*
+ * video_writer.h — MP4 video recording for ag-cam-tools
+ *
+ * Encodes RGB24 stereo frame pairs to H.264 MP4 files.
+ * Requires FFmpeg (libavcodec, libavformat, libswscale).
+ */
+
+#ifndef AG_VIDEO_WRITER_H
+#define AG_VIDEO_WRITER_H
+
+#include <stdint.h>
+
+typedef enum {
+    AG_VIDEO_LAYOUT_SBS,        /* side-by-side: width = eye_w * 2 */
+    AG_VIDEO_LAYOUT_TOP_BOTTOM, /* over-under:   height = eye_h * 2 */
+    AG_VIDEO_LAYOUT_SEPARATE,   /* two files: _left.mp4 + _right.mp4 */
+    AG_VIDEO_LAYOUT_MONO,       /* single-sensor camera: no pair */
+} AgVideoLayout;
+
+typedef struct AgVideoWriter AgVideoWriter;
+
+/*
+ * Parse layout string: "sbs", "tb" / "top-bottom", "separate".
+ * Returns 0 on success, -1 on unrecognised string.
+ */
+int ag_video_layout_parse (const char *str, AgVideoLayout *out);
+
+/*
+ * Create a video writer.
+ *
+ * path:   output MP4 file path.  For SEPARATE layout, the base name
+ *         is used to generate _left.mp4 and _right.mp4 variants.
+ * eye_w:  per-eye frame width in pixels.
+ * eye_h:  per-eye frame height in pixels.
+ * fps:    target frame rate.
+ * layout: stereo layout mode.
+ *
+ * Returns NULL on failure (prints its own diagnostic).
+ */
+AgVideoWriter *ag_video_writer_new (const char *path, int eye_w, int eye_h,
+                                     double fps, AgVideoLayout layout);
+
+/*
+ * Feed a stereo frame pair.
+ *
+ * left_rgb and right_rgb are RGB24 buffers (eye_w * eye_h * 3 bytes each).
+ * The writer composites them according to layout, converts to YUV420P,
+ * encodes, and muxes.
+ *
+ * Returns 0 on success, -1 on error.  Returns -1 if called on a writer
+ * created with AG_VIDEO_LAYOUT_MONO.
+ */
+int ag_video_writer_add_frame (AgVideoWriter *w,
+                                const uint8_t *left_rgb,
+                                const uint8_t *right_rgb);
+
+/*
+ * Feed a single (mono) frame.  rgb is an RGB24 buffer of
+ * eye_w * eye_h * 3 bytes.  Returns 0 on success, -1 on error.
+ * Returns -1 if called on a writer not created with AG_VIDEO_LAYOUT_MONO.
+ */
+int ag_video_writer_add_mono_frame (AgVideoWriter *w, const uint8_t *rgb);
+
+/*
+ * Flush encoder, write MP4 trailer, close file(s), free resources.
+ * Safe to call with NULL (no-op).
+ * Returns the number of frames written, or -1 on error during flush.
+ */
+int64_t ag_video_writer_close (AgVideoWriter *w);
+
+#endif /* AG_VIDEO_WRITER_H */


### PR DESCRIPTION
Closes #24, #25, #26, #27, #28, #29, #30.

## Summary

- `list`, `connect`, `stream`, single-shot `capture` now support monocular Lucid GigE cameras (Triton TRT016S verified) alongside the existing PDH016S stereo head.
- `depth-preview-classical`, `depth-preview-neural`, `depth-capture`, `focus`, `calibration-capture`, and `capture --burst` reject mono cameras with a clear actionable error instead of crashing.
- Sensor topology is auto-detected at camera open by probing `arv_camera_dup_available_pixel_formats_as_strings()`: `DualBayerRG8` ⇒ stereo, `BayerRG8` / `Mono8` ⇒ mono. No model whitelist needed.

## Commits

| Commit | Issue | Summary |
|--------|-------|---------|
| `72d61a8` + `e567635` | #25 | `detect_sensor_mode()` in `common.c`; `AgCameraConfig.sensor_mode` / `pixel_format`; mono geometry uses `WidthMax`/`HeightMax` |
| `b0ad11c` | — | Makefile `-MMD -MP` so header changes trigger consumer rebuilds (the absence of this caused a stack-corruption SIGSEGV during #25 bring-up) |
| `31f0f40` | #26 | `stream`: `AG_VIDEO_LAYOUT_MONO`, `ag_video_writer_add_mono_frame()`, single-eye SDL pipeline, AprilTag mono path, calibration / `--record-layout` rejection |
| `0131d76` | #27 | `capture` mono single-shot (already supported, now logged + tag-detect path); `--burst`, `--calibration-*`, `focus`, `calibration-capture` reject mono |
| `3bf007b` | #28 | `depth-preview-{classical,neural}` + `depth-capture` reject mono with `error: depth-preview requires a stereo Lucid camera; detected monocular sensor on <model> (<serial>)` |
| `17171ed` | #29 | `list` adds MODE column (`stereo`/`mono`/`unknown`) and `--no-probe` flag |
| `c90d5b1` | #30 | `docs/cli/*` Sensor modes sections, README updated |

## Test plan

- [x] `make test` (14 unit tests pass)
- [x] Hardware: TRT016S-C (mono Triton, 1440×1080, BayerRG8) — `list`, `connect`, `stream` (recorded a 12-frame mono MP4), single-shot `capture` (single PGM, no `_left`/`_right` suffix)
- [x] Hardware: PDH016S-C (stereo Phoenix, 2880×1080, DualBayerRG8) — `list`, `stream` (recorded a 14-frame SBS MP4), `capture` (left+right PGM pair) — verified no behavior regression vs `main`
- [x] Hardware mono rejections: `capture --burst`, `capture --calibration-slot`, `focus`, `calibration-capture`, `depth-preview-classical --calibration-slot 0`, `depth-capture --max-depth 200 --calibration-slot 0` all exit 1 with the planned error message

## Known limitations / candidate follow-ups

- Mono burst capture not implemented (would need a non-DualBayer burst pipeline).
- Single-camera intrinsics calibration (`calibration-capture` mono) not implemented.
- Single-camera focus mode not implemented.
- Mono `--tag-size` runs detection but does not render overlays into the saved image.

## Out-of-scope changes pulled in

- The Makefile dependency-tracking commit (`b0ad11c`) was not in the issue tree but landed alongside #25 because the bug it prevents bit during this PR's bring-up. Keeping it here so reviewers don't hit the same trap.

## Notes for reviewer

- User-WIP changes to `cmd_depth_preview.c`, `docs/cli/stream.md`, `docs/cli/depth-preview-classical.md`, `docs/cli/depth-preview-neural.md`, and `mkdocs.yml` (depth-preview MP4 recording) were left untouched on the working tree and **not** included in this branch. They will need to be committed separately.