### PR TITLE
add capture API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CXX     ?= g++
 # layout in common.h) trigger rebuilds of every .c that includes them.
 # Without this, callers compiled against a stale struct size produced
 # silent stack overflows when AgCameraConfig grew.
-CFLAGS  = -Wall -Wextra -O2 -MMD -MP \
+CFLAGS  = -Wall -Wextra -O2 -fPIC -MMD -MP \
           $(shell pkg-config --cflags aravis-0.8) \
           $(shell pkg-config --cflags sdl2)
 LIBS    = $(shell pkg-config --libs aravis-0.8) \
@@ -16,6 +16,7 @@ BINDIR    = bin
 VENDORDIR = vendor
 
 TARGET = $(BINDIR)/ag-cam-tools
+LIB_TARGET = $(BINDIR)/libagrippa.so
 
 SRCS = $(SRCDIR)/main.c \
        $(SRCDIR)/common.c \
@@ -45,7 +46,8 @@ SRCS = $(SRCDIR)/main.c \
        $(SRCDIR)/cmd_bounce.c \
        $(SRCDIR)/burst.c \
        $(SRCDIR)/apriltag_detect.c \
-       $(SRCDIR)/overlay.c
+       $(SRCDIR)/overlay.c \
+       $(SRCDIR)/agrippa.c
 
 VENDOR_SRCS = $(VENDORDIR)/argtable3.c \
               $(VENDORDIR)/cJSON.c
@@ -55,6 +57,12 @@ CXX_SRCS =
 OBJS        = $(patsubst $(SRCDIR)/%.c,$(BINDIR)/%.o,$(SRCS))
 VENDOR_OBJS = $(patsubst $(VENDORDIR)/%.c,$(BINDIR)/%.o,$(VENDOR_SRCS))
 CXX_OBJS    = $(patsubst $(SRCDIR)/%.cpp,$(BINDIR)/%.o,$(CXX_SRCS))
+
+# Objects that go into libagrippa.so: everything except the CLI
+# entry point (main.o) and the argtable-driven cmd_*.o handlers.
+# These are pulled in transitively only by ag-cam-tools.
+LIB_OBJS    = $(filter-out $(BINDIR)/main.o $(BINDIR)/cmd_%.o,$(OBJS)) \
+              $(VENDOR_OBJS) $(CXX_OBJS)
 
 # --- AprilTag: prefer system install, fall back to vendor submodule ---
 APRILTAG_SYSTEM_CFLAGS := $(shell pkg-config --cflags apriltag 2>/dev/null)
@@ -121,12 +129,16 @@ ifneq ($(FFMPEG_LIBS),)
 endif
 
 PREFIX     ?= /usr/local
+LIBDIR     ?= $(PREFIX)/lib
+INCLUDEDIR ?= $(PREFIX)/include
 BASHCOMPDIR ?= $(PREFIX)/share/bash-completion/completions
 ZSHCOMPDIR  ?= $(PREFIX)/share/zsh/site-functions
 
-.PHONY: all clean install uninstall test test-hw test-all
+.PHONY: all clean install uninstall test test-hw test-all lib
 
-all: $(BINDIR) $(TARGET)
+all: $(BINDIR) $(TARGET) $(LIB_TARGET)
+
+lib: $(BINDIR) $(LIB_TARGET)
 
 $(BINDIR):
 	mkdir -p $(BINDIR)
@@ -139,15 +151,16 @@ $(BINDIR)/%.o: $(SRCDIR)/%.cpp | $(BINDIR)
 	$(CXX) $(CFLAGS) -std=c++11 -c -o $@ $<
 
 $(BINDIR)/argtable3.o: $(VENDORDIR)/argtable3.c | $(BINDIR)
-	$(CC) -Wall -O2 -c -o $@ $<
+	$(CC) -Wall -O2 -fPIC -c -o $@ $<
 
 $(BINDIR)/cJSON.o: $(VENDORDIR)/cJSON.c | $(BINDIR)
-	$(CC) -Wall -O2 -c -o $@ $<
+	$(CC) -Wall -O2 -fPIC -c -o $@ $<
 
-# AprilTag vendor object compilation
+# AprilTag vendor object compilation.  -fPIC is required so the vendored
+# static library can be linked into libagrippa.so.
 $(BINDIR)/apriltag/%.o: $(APRILTAG_DIR)/%.c | $(BINDIR)
 	@mkdir -p $(dir $@)
-	$(CC) -Wall -O2 -I$(APRILTAG_DIR) -c -o $@ $<
+	$(CC) -Wall -O2 -fPIC -I$(APRILTAG_DIR) -c -o $@ $<
 
 # AprilTag vendor static library
 $(APRILTAG_LIB): $(APRILTAG_OBJS)
@@ -157,13 +170,22 @@ $(TARGET): $(OBJS) $(VENDOR_OBJS) $(CXX_OBJS) $(APRILTAG_LIB)
 	$(CC) -o $@ $(OBJS) $(VENDOR_OBJS) $(CXX_OBJS) $(if $(APRILTAG_LIB),-L$(BINDIR) -lapriltag) $(LIBS)
 	codesign --force --sign - $@ 2>/dev/null || true
 
+$(LIB_TARGET): $(LIB_OBJS) $(APRILTAG_LIB)
+	$(CC) -shared -Wl,-soname,libagrippa.so -o $@ $(LIB_OBJS) \
+	      $(if $(APRILTAG_LIB),-L$(BINDIR) -lapriltag) $(LIBS)
+	codesign --force --sign - $@ 2>/dev/null || true
+
 # Pull in header-dependency files emitted by -MMD/-MP.  Missing files
 # (first build) are ignored thanks to the leading dash.
 -include $(OBJS:.o=.d) $(VENDOR_OBJS:.o=.d) $(CXX_OBJS:.o=.d)
 
-install: $(TARGET)
+install: $(TARGET) $(LIB_TARGET)
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -m 755 $(TARGET) $(DESTDIR)$(PREFIX)/bin/
+	install -d $(DESTDIR)$(LIBDIR)
+	install -m 755 $(LIB_TARGET) $(DESTDIR)$(LIBDIR)/
+	install -d $(DESTDIR)$(INCLUDEDIR)/agrippa
+	install -m 644 $(SRCDIR)/agrippa.h $(DESTDIR)$(INCLUDEDIR)/agrippa/
 	install -d $(DESTDIR)$(BASHCOMPDIR)
 	install -m 644 completions/ag-cam-tools.bash $(DESTDIR)$(BASHCOMPDIR)/ag-cam-tools
 	install -d $(DESTDIR)$(ZSHCOMPDIR)
@@ -171,6 +193,8 @@ install: $(TARGET)
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/ag-cam-tools
+	rm -f $(DESTDIR)$(LIBDIR)/libagrippa.so
+	rm -rf $(DESTDIR)$(INCLUDEDIR)/agrippa
 	rm -f $(DESTDIR)$(BASHCOMPDIR)/ag-cam-tools
 	rm -f $(DESTDIR)$(ZSHCOMPDIR)/_ag-cam-tools
 

--- a/docs/development/library-api.md
+++ b/docs/development/library-api.md
@@ -64,7 +64,7 @@ ag_camera_close(cam);
 | `auto_expose` | When set to 1, runs auto-expose-and-lock at open time. Mutually exclusive with manual exposure / gain. |
 | `binning` | Sensor binning (1 or 2). |
 | `packet_size` | GigE packet size, or 0 to auto-negotiate. |
-| `calibration_local_path` / `calibration_slot` | Optional rectification source. Mutually exclusive; the loaded `AgRemapTable`s are accessible via `ag_camera_get_remap_left/right`. |
+| `calibration_local_path` / `calibration_slot` | Optional rectification source. Mutually exclusive. When set, remap tables are loaded at open time and applied automatically on every `ag_camera_capture()` call — `AgFrame.left`/`right` are returned already rectified (stereo-aligned). The tables are also accessible via `ag_camera_get_remap_left/right` for callers that need them directly. |
 | `continuous` | 1 (recommended) starts continuous acquisition once at open time and pays only the per-frame software-trigger cost on each `ag_camera_capture()`; 0 mimics `ag-cam-tools capture`'s SingleFrame behaviour and restarts acquisition every capture. |
 | `verbose` | Diagnostic prints during configuration. |
 
@@ -72,14 +72,15 @@ ag_camera_close(cam);
 
 | Field | Meaning |
 |-------|---------|
-| `left`, `right` | Per-eye Bayer planes. `right` is `NULL` for monocular Lucid cameras (BayerRG8 / Mono8). |
+| `left`, `right` | Per-eye image data. Without calibration: raw Bayer/gray `(H × W × 1)`. With calibration: debayered + rectified RGB24 `(H × W × 3)`. `right` is `NULL` for monocular cameras. |
 | `width`, `height` | Per-eye dimensions after software binning. |
+| `channels` | Bytes per pixel: `1` for raw Bayer/gray (no calibration), `3` for rectified RGB24 (calibration configured). |
 | `frame_id`, `timestamp_ns` | Camera-reported metadata. |
 
 ### Entry points
 
 - `ag_camera_open(const AgOpenParams *)` &mdash; opens the camera, configures it, and starts acquisition when `continuous=1`.
-- `ag_camera_capture(AgCamera *, AgFrame *)` &mdash; software-triggers a frame, splits DualBayerRG8 into per-eye planes, and returns 0 on success.
+- `ag_camera_capture(AgCamera *, AgFrame *)` &mdash; software-triggers a frame, splits DualBayerRG8 into per-eye planes, and returns 0 on success. When calibration is configured, applies the full rectification pipeline (gamma-correct → debayer → remap) and sets `AgFrame.channels = 3` (RGB24 output), matching the output of `ag-cam-tools capture --calibration-slot`. Without calibration, `AgFrame.channels = 1` (raw Bayer/gray).
 - `ag_camera_release_frame(AgCamera *, AgFrame *)` &mdash; no-op in this revision; reserved so a future zero-copy buffer hand-off can be added without an ABI break.
 - `ag_camera_close(AgCamera *)` &mdash; stops acquisition (if running), frees rectification tables, and tears down the camera handle. Does not call `arv_shutdown()` so subsequent opens keep their discovery cache warm.
 - `ag_camera_last_error(AgCamera *)` &mdash; last diagnostic string captured on this handle.
@@ -113,6 +114,3 @@ beyond the next capture must copy it. The Python wrapper in
   detector on the per-eye Bayer planes if they need it).
 - Zero-copy buffer hand-off; `ag_camera_capture` always copies the
   current Aravis buffer into the handle's scratch space.
-- Applying rectification inside the library; tables are loaded and
-  validated, but rectification is currently the caller's
-  responsibility via `ag_camera_get_remap_*`.

--- a/docs/development/library-api.md
+++ b/docs/development/library-api.md
@@ -1,0 +1,118 @@
+# libagrippa: C library API
+
+`libagrippa.so` exposes the same camera open / configure / capture
+pipeline used internally by `ag-cam-tools` as a reusable shared
+library, so non-CLI consumers (Python wrappers, robotics frameworks,
+test harnesses, etc.) can keep a persistent camera handle and avoid
+the per-frame cost of spawning a fresh subprocess and re-running GigE
+Vision discovery.
+
+The public header is [`src/agrippa.h`](../../src/agrippa.h). The CLI's
+`ag-cam-tools capture` single-frame path is implemented on top of this
+library, so the CLI itself acts as a regression check for the API.
+
+## Build and install
+
+`libagrippa.so` is built by the default `make` target alongside
+`bin/ag-cam-tools`:
+
+```bash
+make
+sudo make install
+```
+
+`make install` places:
+
+- `libagrippa.so` under `$PREFIX/lib/`
+- `agrippa.h` under `$PREFIX/include/agrippa/`
+
+Use `make lib` to build only the shared library when iterating on a
+Python wrapper.
+
+## API surface
+
+```c
+#include <agrippa/agrippa.h>
+
+AgOpenParams params = {
+    .address    = "192.168.9.17",
+    .binning    = 1,
+    .continuous = 1,
+};
+AgCamera *cam = ag_camera_open(&params);
+
+AgFrame frame;
+while (ag_camera_capture(cam, &frame) == 0) {
+    /* frame.left, frame.right are per-eye Bayer planes of
+     * frame.width * frame.height bytes each.  The buffers are valid
+     * until the next ag_camera_capture() call. */
+    process(frame.left, frame.right, frame.width, frame.height);
+    ag_camera_release_frame(cam, &frame);
+}
+
+ag_camera_close(cam);
+```
+
+### `AgOpenParams`
+
+| Field | Meaning |
+|-------|---------|
+| `address` / `serial` | Mutually exclusive camera selectors. At least one must be non-NULL. |
+| `interface_name` | Optional NIC name (forces `ARV_INTERFACE`). |
+| `exposure_us` | Manual exposure in microseconds, or `<=0` to keep the camera default. |
+| `gain_db` | Manual gain in dB (0-48), or `<0` to keep the camera default. |
+| `auto_expose` | When set to 1, runs auto-expose-and-lock at open time. Mutually exclusive with manual exposure / gain. |
+| `binning` | Sensor binning (1 or 2). |
+| `packet_size` | GigE packet size, or 0 to auto-negotiate. |
+| `calibration_local_path` / `calibration_slot` | Optional rectification source. Mutually exclusive; the loaded `AgRemapTable`s are accessible via `ag_camera_get_remap_left/right`. |
+| `continuous` | 1 (recommended) starts continuous acquisition once at open time and pays only the per-frame software-trigger cost on each `ag_camera_capture()`; 0 mimics `ag-cam-tools capture`'s SingleFrame behaviour and restarts acquisition every capture. |
+| `verbose` | Diagnostic prints during configuration. |
+
+### `AgFrame`
+
+| Field | Meaning |
+|-------|---------|
+| `left`, `right` | Per-eye Bayer planes. `right` is `NULL` for monocular Lucid cameras (BayerRG8 / Mono8). |
+| `width`, `height` | Per-eye dimensions after software binning. |
+| `frame_id`, `timestamp_ns` | Camera-reported metadata. |
+
+### Entry points
+
+- `ag_camera_open(const AgOpenParams *)` &mdash; opens the camera, configures it, and starts acquisition when `continuous=1`.
+- `ag_camera_capture(AgCamera *, AgFrame *)` &mdash; software-triggers a frame, splits DualBayerRG8 into per-eye planes, and returns 0 on success.
+- `ag_camera_release_frame(AgCamera *, AgFrame *)` &mdash; no-op in this revision; reserved so a future zero-copy buffer hand-off can be added without an ABI break.
+- `ag_camera_close(AgCamera *)` &mdash; stops acquisition (if running), frees rectification tables, and tears down the camera handle. Does not call `arv_shutdown()` so subsequent opens keep their discovery cache warm.
+- `ag_camera_last_error(AgCamera *)` &mdash; last diagnostic string captured on this handle.
+
+Accessors:
+
+- `ag_camera_is_stereo` &mdash; 1 for DualBayerRG8 heads, 0 for monocular cameras.
+- `ag_camera_data_is_bayer` &mdash; 1 when the captured planes still carry a valid Bayer CFA, 0 when binning destroyed the mosaic (see [binning-and-bayer](binning-and-bayer.md)).
+- `ag_camera_get_remap_left` / `ag_camera_get_remap_right` &mdash; borrowed pointers to the library-owned rectification tables.
+
+## Threading
+
+An `AgCamera` handle is not internally synchronised. Serialise access
+externally if multiple threads share a single handle. Different
+handles addressing different cameras can be used concurrently.
+
+## Memory model
+
+`AgFrame.left` and `AgFrame.right` point into scratch buffers owned by
+the `AgCamera` handle. The buffers are reused on every
+`ag_camera_capture()` call, so callers that need to keep frame data
+beyond the next capture must copy it. The Python wrapper in
+[makeit-vision](https://github.com/) does exactly this via
+`np.frombuffer(...).copy()`.
+
+## Out of scope (for the initial revision)
+
+- FrameBurstStart triggering (`ag-cam-tools capture --burst` still
+  uses its own raw-Aravis pipeline).
+- AprilTag detection through the library (callers run their own
+  detector on the per-eye Bayer planes if they need it).
+- Zero-copy buffer hand-off; `ag_camera_capture` always copies the
+  current Aravis buffer into the handle's scratch space.
+- Applying rectification inside the library; tables are loaded and
+  validated, but rectification is currently the caller's
+  responsibility via `ag_camera_get_remap_*`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,3 +40,4 @@ nav:
       - Circuits: hardware/circuits.md
   - Development:
       - Binning and Bayer Notes: development/binning-and-bayer.md
+      - libagrippa C API: development/library-api.md

--- a/models/igev_plusplus.onnx
+++ b/models/igev_plusplus.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eadd6dc5cf028274bd702ffbf3404b703164bb6616c236e4e9fa2a6e4edfc183
-size 2093589979

--- a/src/agrippa.c
+++ b/src/agrippa.c
@@ -1,0 +1,484 @@
+/*
+ * agrippa.c — libagrippa implementation
+ *
+ * Thin wrapper over the existing helpers in common.c / imgproc.c /
+ * calib_load.c that exposes a persistent camera handle suitable for
+ * driving from Python (or any non-CLI consumer) without spawning a
+ * new ag-cam-tools subprocess per frame.
+ */
+
+#include "agrippa.h"
+
+#include "common.h"
+#include "imgproc.h"
+#include "calib_load.h"
+#include "remap.h"
+
+#include <arv.h>
+#include <glib.h>
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define AG_ERROR_BUF_LEN     512
+#define AG_POP_TIMEOUT_US    5000000
+#define AG_POP_MAX_ATTEMPTS  10
+#define AG_TRIGGER_POLL_MAX  100
+#define AG_TRIGGER_POLL_US   10000
+#define AG_AE_INTERVAL_US    100000.0
+
+struct AgCamera {
+    ArvCamera     *camera;
+    AgCameraConfig cfg;
+
+    /* Optional rectification tables, validated against the captured
+     * frame geometry but not applied to AgFrame data in this revision. */
+    AgRemapTable  *remap_left;
+    AgRemapTable  *remap_right;
+
+    gboolean       continuous;
+    gboolean       acquisition_running;
+    gboolean       auto_expose_done;
+    double         pending_exposure_us;
+    double         pending_gain_db;
+    gboolean       auto_expose_requested;
+
+    /* Scratch buffers for split Bayer planes; sized to one eye for
+     * stereo, or the full sensor for mono.  Reused across captures so
+     * the buffers returned via AgFrame.left/right remain valid until
+     * the next capture or close. */
+    guint8        *left_buf;
+    guint8        *right_buf;
+    guint          sub_w;
+    guint          sub_h;
+    size_t         eye_n_bytes;
+
+    char           last_error[AG_ERROR_BUF_LEN];
+};
+
+static void
+ag_set_error (AgCamera *cam, const char *fmt, ...)
+{
+    if (!cam)
+        return;
+    va_list ap;
+    va_start (ap, fmt);
+    g_vsnprintf (cam->last_error, sizeof cam->last_error, fmt, ap);
+    va_end (ap);
+}
+
+static void
+ag_clear_error (AgCamera *cam)
+{
+    if (cam)
+        cam->last_error[0] = '\0';
+}
+
+static int
+ag_start_acquisition (AgCamera *cam)
+{
+    GError *error = NULL;
+    arv_camera_start_acquisition (cam->camera, &error);
+    if (error) {
+        ag_set_error (cam, "failed to start acquisition: %s", error->message);
+        g_clear_error (&error);
+        return -1;
+    }
+    cam->acquisition_running = TRUE;
+    return 0;
+}
+
+static void
+ag_stop_acquisition (AgCamera *cam)
+{
+    if (!cam->acquisition_running)
+        return;
+    arv_camera_stop_acquisition (cam->camera, NULL);
+    cam->acquisition_running = FALSE;
+}
+
+static gboolean
+ag_wait_trigger_armed (AgCamera *cam)
+{
+    ArvDevice *device = arv_camera_get_device (cam->camera);
+    gboolean armed = FALSE;
+    for (int p = 0; p < AG_TRIGGER_POLL_MAX && !armed; p++) {
+        GError *e = NULL;
+        armed = arv_device_get_boolean_feature_value (device, "TriggerArmed", &e);
+        g_clear_error (&e);
+        if (!armed)
+            g_usleep (AG_TRIGGER_POLL_US);
+    }
+    return armed;
+}
+
+static int
+ag_fire_trigger (AgCamera *cam)
+{
+    ArvDevice *device = arv_camera_get_device (cam->camera);
+    GError *e = NULL;
+    arv_device_execute_command (device, "TriggerSoftware", &e);
+    if (e) {
+        ag_set_error (cam, "TriggerSoftware failed: %s", e->message);
+        g_clear_error (&e);
+        return -1;
+    }
+    return 0;
+}
+
+static ArvBuffer *
+ag_pop_good_buffer (AgCamera *cam)
+{
+    ArvBuffer *partial = NULL;
+
+    for (int i = 0; i < AG_POP_MAX_ATTEMPTS; i++) {
+        ArvBuffer *b = arv_stream_timeout_pop_buffer (cam->cfg.stream,
+                                                       AG_POP_TIMEOUT_US);
+        if (!b)
+            continue;
+
+        ArvBufferStatus st = arv_buffer_get_status (b);
+        if (st == ARV_BUFFER_STATUS_SUCCESS) {
+            if (partial)
+                arv_stream_push_buffer (cam->cfg.stream, partial);
+            return b;
+        }
+
+        if (partial)
+            arv_stream_push_buffer (cam->cfg.stream, partial);
+        partial = b;
+    }
+
+    if (partial)
+        arv_stream_push_buffer (cam->cfg.stream, partial);
+    ag_set_error (cam, "timeout waiting for frame after %d attempts",
+                  AG_POP_MAX_ATTEMPTS);
+    return NULL;
+}
+
+static int
+ag_load_calibration (AgCamera *cam, const AgOpenParams *params)
+{
+    if (!params->calibration_local_path && params->calibration_slot < 0)
+        return 0;
+
+    if (params->calibration_local_path && params->calibration_slot >= 0) {
+        ag_set_error (cam,
+                      "calibration_local_path and calibration_slot are "
+                      "mutually exclusive");
+        return -1;
+    }
+
+    if (cam->cfg.sensor_mode == AG_SENSOR_MONO) {
+        ag_set_error (cam,
+                      "calibration is stereo-only; not applicable to mono cameras");
+        return -1;
+    }
+
+    AgCalibSource src = {
+        .local_path = params->calibration_local_path,
+        .slot       = (params->calibration_local_path
+                         ? -1 : params->calibration_slot),
+    };
+
+    ArvDevice *device = arv_camera_get_device (cam->camera);
+    if (ag_calib_load (device, &src,
+                       &cam->remap_left, &cam->remap_right, NULL) != 0) {
+        ag_set_error (cam, "failed to load calibration");
+        return -1;
+    }
+
+    guint proc_sub_w = (cam->cfg.frame_w / 2)
+                       / (guint) cam->cfg.software_binning;
+    guint proc_h     = cam->cfg.frame_h / (guint) cam->cfg.software_binning;
+    if (cam->remap_left->width  != proc_sub_w ||
+        cam->remap_left->height != proc_h) {
+        ag_set_error (cam,
+                      "remap dimensions %ux%u do not match frame %ux%u",
+                      cam->remap_left->width, cam->remap_left->height,
+                      proc_sub_w, proc_h);
+        ag_remap_table_free (cam->remap_left);
+        ag_remap_table_free (cam->remap_right);
+        cam->remap_left  = NULL;
+        cam->remap_right = NULL;
+        return -1;
+    }
+
+    return 0;
+}
+
+AgCamera *
+ag_camera_open (const AgOpenParams *params)
+{
+    if (!params) {
+        fprintf (stderr, "ag_camera_open: NULL params\n");
+        return NULL;
+    }
+
+    if (params->binning != 1 && params->binning != 2) {
+        fprintf (stderr, "ag_camera_open: binning must be 1 or 2 (got %d)\n",
+                 params->binning);
+        return NULL;
+    }
+    if (params->auto_expose &&
+        (params->exposure_us > 0.0 || params->gain_db >= 0.0)) {
+        fprintf (stderr, "ag_camera_open: auto_expose and exposure/gain are "
+                         "mutually exclusive\n");
+        return NULL;
+    }
+    if (params->address && params->serial) {
+        fprintf (stderr, "ag_camera_open: address and serial are mutually exclusive\n");
+        return NULL;
+    }
+    if (!params->address && !params->serial) {
+        fprintf (stderr, "ag_camera_open: one of address or serial must be set\n");
+        return NULL;
+    }
+
+    const char *iface_ip = NULL;
+    if (params->interface_name) {
+        iface_ip = setup_interface (params->interface_name);
+        if (!iface_ip)
+            return NULL;
+    }
+
+    char *device_id = resolve_device (params->serial, params->address,
+                                       params->interface_name, FALSE);
+    if (!device_id)
+        return NULL;
+
+    GError *error = NULL;
+    ArvCamera *arv_cam = arv_camera_new (device_id, &error);
+    g_free (device_id);
+    if (!arv_cam) {
+        fprintf (stderr, "ag_camera_open: %s\n",
+                 error ? error->message : "failed to open device");
+        g_clear_error (&error);
+        return NULL;
+    }
+
+    AgCamera *cam = g_new0 (AgCamera, 1);
+    cam->camera     = arv_cam;
+    cam->continuous = params->continuous ? TRUE : FALSE;
+
+    AgAcquisitionMode mode = cam->continuous ? AG_MODE_CONTINUOUS
+                                              : AG_MODE_SINGLE_FRAME;
+
+    if (camera_configure (arv_cam, mode,
+                          params->binning,
+                          params->exposure_us,
+                          params->gain_db,
+                          params->auto_expose ? TRUE : FALSE,
+                          params->packet_size,
+                          iface_ip,
+                          params->verbose ? TRUE : FALSE,
+                          &cam->cfg) != EXIT_SUCCESS) {
+        ag_set_error (cam, "camera_configure failed");
+        fprintf (stderr, "ag_camera_open: %s\n", cam->last_error);
+        g_object_unref (arv_cam);
+        g_free (cam);
+        return NULL;
+    }
+
+    if (ag_load_calibration (cam, params) != 0) {
+        fprintf (stderr, "ag_camera_open: %s\n", cam->last_error);
+        g_object_unref (cam->cfg.stream);
+        g_object_unref (arv_cam);
+        g_free (cam);
+        return NULL;
+    }
+
+    /* Per-eye output dimensions after software binning. */
+    if (cam->cfg.sensor_mode == AG_SENSOR_STEREO) {
+        cam->sub_w = (cam->cfg.frame_w / 2)
+                     / (guint) cam->cfg.software_binning;
+        cam->sub_h = cam->cfg.frame_h
+                     / (guint) cam->cfg.software_binning;
+    } else {
+        cam->sub_w = cam->cfg.frame_w / (guint) cam->cfg.software_binning;
+        cam->sub_h = cam->cfg.frame_h / (guint) cam->cfg.software_binning;
+    }
+    cam->eye_n_bytes = (size_t) cam->sub_w * (size_t) cam->sub_h;
+    cam->left_buf    = g_malloc (cam->eye_n_bytes);
+    if (cam->cfg.sensor_mode == AG_SENSOR_STEREO)
+        cam->right_buf = g_malloc (cam->eye_n_bytes);
+
+    cam->auto_expose_requested = params->auto_expose ? TRUE : FALSE;
+    cam->auto_expose_done      = FALSE;
+
+    if (cam->continuous) {
+        if (ag_start_acquisition (cam) != 0) {
+            fprintf (stderr, "ag_camera_open: %s\n", cam->last_error);
+            ag_camera_close (cam);
+            return NULL;
+        }
+        if (cam->auto_expose_requested) {
+            auto_expose_settle (cam->camera, &cam->cfg, AG_AE_INTERVAL_US);
+            cam->auto_expose_done = TRUE;
+        }
+    }
+
+    return cam;
+}
+
+int
+ag_camera_capture (AgCamera *cam, AgFrame *out)
+{
+    if (!cam) {
+        fprintf (stderr, "ag_camera_capture: NULL handle\n");
+        return -1;
+    }
+    if (!out) {
+        ag_set_error (cam, "NULL out parameter");
+        return -1;
+    }
+
+    ag_clear_error (cam);
+
+    if (!cam->acquisition_running) {
+        if (ag_start_acquisition (cam) != 0)
+            return -1;
+        if (cam->auto_expose_requested && !cam->auto_expose_done) {
+            auto_expose_settle (cam->camera, &cam->cfg, AG_AE_INTERVAL_US);
+            cam->auto_expose_done = TRUE;
+        }
+    }
+
+    if (!ag_wait_trigger_armed (cam))
+        fprintf (stderr, "warn: TriggerArmed not set, triggering anyway\n");
+
+    if (ag_fire_trigger (cam) != 0)
+        goto fail;
+
+    ArvBuffer *buffer = ag_pop_good_buffer (cam);
+    if (!buffer)
+        goto fail;
+
+    size_t data_size = 0;
+    const guint8 *data = arv_buffer_get_data (buffer, &data_size);
+    guint width  = arv_buffer_get_image_width  (buffer);
+    guint height = arv_buffer_get_image_height (buffer);
+    size_t needed = (size_t) width * (size_t) height;
+
+    if (!data || data_size < needed) {
+        ag_set_error (cam,
+                      "unsupported buffer (%zu bytes for %ux%u, need %zu)",
+                      data_size, width, height, needed);
+        arv_stream_push_buffer (cam->cfg.stream, buffer);
+        goto fail;
+    }
+
+    if (cam->cfg.sensor_mode == AG_SENSOR_STEREO) {
+        if (width != cam->cfg.frame_w || height != cam->cfg.frame_h) {
+            ag_set_error (cam, "unexpected frame %ux%u (expected %ux%u)",
+                          width, height, cam->cfg.frame_w, cam->cfg.frame_h);
+            arv_stream_push_buffer (cam->cfg.stream, buffer);
+            goto fail;
+        }
+        extract_dual_bayer_eyes (data, width, height,
+                                  cam->cfg.software_binning,
+                                  cam->left_buf, cam->right_buf);
+        out->left  = cam->left_buf;
+        out->right = cam->right_buf;
+    } else {
+        if (width != cam->cfg.frame_w || height != cam->cfg.frame_h) {
+            ag_set_error (cam, "unexpected frame %ux%u (expected %ux%u)",
+                          width, height, cam->cfg.frame_w, cam->cfg.frame_h);
+            arv_stream_push_buffer (cam->cfg.stream, buffer);
+            goto fail;
+        }
+        if (cam->cfg.software_binning > 1) {
+            software_bin_2x2 (data, width, height,
+                              cam->left_buf, cam->sub_w, cam->sub_h);
+        } else {
+            memcpy (cam->left_buf, data, cam->eye_n_bytes);
+        }
+        out->left  = cam->left_buf;
+        out->right = NULL;
+    }
+
+    out->width        = cam->sub_w;
+    out->height       = cam->sub_h;
+    out->frame_id     = (unsigned long) arv_buffer_get_frame_id  (buffer);
+    out->timestamp_ns = (unsigned long) arv_buffer_get_timestamp (buffer);
+
+    arv_stream_push_buffer (cam->cfg.stream, buffer);
+
+    if (!cam->continuous)
+        ag_stop_acquisition (cam);
+
+    return 0;
+
+fail:
+    if (!cam->continuous)
+        ag_stop_acquisition (cam);
+    return -1;
+}
+
+void
+ag_camera_release_frame (AgCamera *cam, AgFrame *frame)
+{
+    (void) cam;
+    if (frame)
+        memset (frame, 0, sizeof *frame);
+}
+
+void
+ag_camera_close (AgCamera *cam)
+{
+    if (!cam)
+        return;
+
+    ag_stop_acquisition (cam);
+
+    if (cam->remap_left)  ag_remap_table_free (cam->remap_left);
+    if (cam->remap_right) ag_remap_table_free (cam->remap_right);
+
+    g_free (cam->left_buf);
+    g_free (cam->right_buf);
+
+    if (cam->cfg.stream)
+        g_object_unref (cam->cfg.stream);
+    if (cam->camera)
+        g_object_unref (cam->camera);
+
+    g_free (cam);
+}
+
+const char *
+ag_camera_last_error (AgCamera *cam)
+{
+    if (!cam)
+        return "";
+    return cam->last_error;
+}
+
+int
+ag_camera_is_stereo (const AgCamera *cam)
+{
+    if (!cam)
+        return 0;
+    return cam->cfg.sensor_mode == AG_SENSOR_STEREO ? 1 : 0;
+}
+
+int
+ag_camera_data_is_bayer (const AgCamera *cam)
+{
+    if (!cam)
+        return 0;
+    return cam->cfg.data_is_bayer ? 1 : 0;
+}
+
+const AgRemapTable *
+ag_camera_get_remap_left (const AgCamera *cam)
+{
+    return cam ? cam->remap_left : NULL;
+}
+
+const AgRemapTable *
+ag_camera_get_remap_right (const AgCamera *cam)
+{
+    return cam ? cam->remap_right : NULL;
+}

--- a/src/agrippa.c
+++ b/src/agrippa.c
@@ -33,10 +33,21 @@ struct AgCamera {
     ArvCamera     *camera;
     AgCameraConfig cfg;
 
-    /* Optional rectification tables, validated against the captured
-     * frame geometry but not applied to AgFrame data in this revision. */
+    /* Optional rectification tables loaded when calibration is configured. */
     AgRemapTable  *remap_left;
     AgRemapTable  *remap_right;
+
+    /* Intermediate debayer buffers (3 × eye_n_bytes, RGB).  Allocated only
+     * when remap tables are present and data_is_bayer is true.  The pipeline
+     * is: Bayer → debayer_rg8_to_rgb → left_rgb_buf → ag_remap_rgb →
+     * left_rect_buf, which preserves the Bayer CFA pattern alignment. */
+    guint8        *left_rgb_buf;
+    guint8        *right_rgb_buf;
+
+    /* Rectified output buffers returned via AgFrame.left/right.
+     * 3 × eye_n_bytes when data_is_bayer (RGB output), eye_n_bytes otherwise. */
+    guint8        *left_rect_buf;
+    guint8        *right_rect_buf;
 
     gboolean       continuous;
     gboolean       acquisition_running;
@@ -305,6 +316,18 @@ ag_camera_open (const AgOpenParams *params)
     if (cam->cfg.sensor_mode == AG_SENSOR_STEREO)
         cam->right_buf = g_malloc (cam->eye_n_bytes);
 
+    if (cam->remap_left) {
+        if (cam->cfg.data_is_bayer) {
+            cam->left_rgb_buf   = g_malloc (cam->eye_n_bytes * 3);
+            cam->right_rgb_buf  = g_malloc (cam->eye_n_bytes * 3);
+            cam->left_rect_buf  = g_malloc (cam->eye_n_bytes * 3);
+            cam->right_rect_buf = g_malloc (cam->eye_n_bytes * 3);
+        } else {
+            cam->left_rect_buf  = g_malloc (cam->eye_n_bytes);
+            cam->right_rect_buf = g_malloc (cam->eye_n_bytes);
+        }
+    }
+
     cam->auto_expose_requested = params->auto_expose ? TRUE : FALSE;
     cam->auto_expose_done      = FALSE;
 
@@ -380,8 +403,31 @@ ag_camera_capture (AgCamera *cam, AgFrame *out)
         extract_dual_bayer_eyes (data, width, height,
                                   cam->cfg.software_binning,
                                   cam->left_buf, cam->right_buf);
-        out->left  = cam->left_buf;
-        out->right = cam->right_buf;
+        if (cam->remap_left) {
+            if (cam->cfg.data_is_bayer) {
+                apply_lut_inplace (cam->left_buf,  cam->eye_n_bytes, gamma_lut_2p5 ());
+                apply_lut_inplace (cam->right_buf, cam->eye_n_bytes, gamma_lut_2p5 ());
+                debayer_rg8_to_rgb (cam->left_buf,  cam->left_rgb_buf,
+                                    cam->sub_w, cam->sub_h);
+                debayer_rg8_to_rgb (cam->right_buf, cam->right_rgb_buf,
+                                    cam->sub_w, cam->sub_h);
+                ag_remap_rgb (cam->remap_left,  cam->left_rgb_buf,  cam->left_rect_buf);
+                ag_remap_rgb (cam->remap_right, cam->right_rgb_buf, cam->right_rect_buf);
+                out->channels = 3;
+            } else {
+                apply_lut_inplace (cam->left_buf,  cam->eye_n_bytes, gamma_lut_2p5 ());
+                apply_lut_inplace (cam->right_buf, cam->eye_n_bytes, gamma_lut_2p5 ());
+                ag_remap_gray (cam->remap_left,  cam->left_buf,  cam->left_rect_buf);
+                ag_remap_gray (cam->remap_right, cam->right_buf, cam->right_rect_buf);
+                out->channels = 1;
+            }
+            out->left  = cam->left_rect_buf;
+            out->right = cam->right_rect_buf;
+        } else {
+            out->left     = cam->left_buf;
+            out->right    = cam->right_buf;
+            out->channels = 1;
+        }
     } else {
         if (width != cam->cfg.frame_w || height != cam->cfg.frame_h) {
             ag_set_error (cam, "unexpected frame %ux%u (expected %ux%u)",
@@ -395,8 +441,9 @@ ag_camera_capture (AgCamera *cam, AgFrame *out)
         } else {
             memcpy (cam->left_buf, data, cam->eye_n_bytes);
         }
-        out->left  = cam->left_buf;
-        out->right = NULL;
+        out->left     = cam->left_buf;
+        out->right    = NULL;
+        out->channels = 1;
     }
 
     out->width        = cam->sub_w;
@@ -438,6 +485,10 @@ ag_camera_close (AgCamera *cam)
 
     g_free (cam->left_buf);
     g_free (cam->right_buf);
+    g_free (cam->left_rgb_buf);
+    g_free (cam->right_rgb_buf);
+    g_free (cam->left_rect_buf);
+    g_free (cam->right_rect_buf);
 
     if (cam->cfg.stream)
         g_object_unref (cam->cfg.stream);

--- a/src/agrippa.h
+++ b/src/agrippa.h
@@ -52,7 +52,9 @@ typedef struct {
 
     /* Optional rectification: either a local calibration session path
      * or an on-camera slot index (0-2).  Set calibration_local_path to
-     * NULL and calibration_slot to -1 to skip. */
+     * NULL and calibration_slot to -1 to skip.  When set, remap tables
+     * are loaded at open time and applied automatically on every
+     * ag_camera_capture(), so AgFrame.left/right are already rectified. */
     const char *calibration_local_path;
     int         calibration_slot;
 
@@ -68,11 +70,16 @@ typedef struct {
 } AgOpenParams;
 
 typedef struct {
-    /* Raw Bayer planes for the captured frame.
+    /* Image data for the captured frame.
      *
-     * For stereo cameras (DualBayerRG8): left and right each point at
-     * a width*height single-eye plane, where width = sub-eye width
-     * after software binning and height = full frame height after
+     * When calibration was configured (calibration_local_path or
+     * calibration_slot), the pipeline is: gamma-correct → debayer → remap, and
+     * left/right contain interleaved RGB24 data (channels == 3).
+     * Without calibration, left/right hold raw Bayer or grayscale data
+     * (channels == 1).
+     *
+     * For stereo cameras (DualBayerRG8): left and right each point at a
+     * width*height*channels buffer, where width is the per-eye width after
      * software binning.
      *
      * For mono cameras (BayerRG8/Mono8): left points at the full
@@ -86,6 +93,10 @@ typedef struct {
     /* Per-eye buffer dimensions (post-binning). */
     unsigned int   width;
     unsigned int   height;
+
+    /* Bytes per pixel: 1 for raw Bayer/gray (no calibration), 3 for
+     * rectified RGB24 (calibration configured). */
+    unsigned int   channels;
 
     /* Camera-reported frame id and timestamp in nanoseconds. */
     unsigned long  frame_id;

--- a/src/agrippa.h
+++ b/src/agrippa.h
@@ -1,0 +1,161 @@
+/*
+ * agrippa.h — public C API for libagrippa
+ *
+ * Exposes the same camera open/configure/capture pipeline used by
+ * ag-cam-tools, but as a reusable shared library with a persistent
+ * camera handle.  Each capture returns Bayer planes (split from
+ * DualBayerRG8 for stereo Lucid heads, or the single sensor plane for
+ * monocular Lucid cameras) without going through disk.
+ *
+ * Memory model:
+ *   - ag_camera_open() returns an opaque handle owned by the caller.
+ *   - ag_camera_capture() points AgFrame.left / AgFrame.right at
+ *     library-owned scratch buffers that remain valid until the next
+ *     ag_camera_capture() or ag_camera_close().  The caller should
+ *     copy the data if it needs to outlive the next capture.
+ *   - ag_camera_release_frame() is a no-op in this revision but is
+ *     part of the API so callers can opt into a zero-copy buffer
+ *     hand-off in the future without an ABI break.
+ *
+ * Thread safety: an AgCamera handle is not internally synchronized.
+ * Callers must serialize access to a given handle.
+ */
+
+#ifndef AGRIPPA_H
+#define AGRIPPA_H
+
+#include "remap.h"   /* for AgRemapTable, exposed via ag_camera_get_remap_* */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct AgCamera AgCamera;
+
+typedef struct {
+    /* Camera selection.  At most one of address / serial may be set;
+     * pass NULL for unused fields.  interface_name forces a NIC. */
+    const char *address;
+    const char *serial;
+    const char *interface_name;
+
+    /* Exposure / gain.  Pass exposure_us <= 0 or gain_db < 0 to leave
+     * the camera default in place.  auto_expose=1 overrides both and
+     * runs an auto-expose-and-lock pass at open time. */
+    double      exposure_us;
+    double      gain_db;
+    int         auto_expose;
+
+    /* Sensor binning (1 or 2) and GigE packet size (0 = auto). */
+    int         binning;
+    int         packet_size;
+
+    /* Optional rectification: either a local calibration session path
+     * or an on-camera slot index (0-2).  Set calibration_local_path to
+     * NULL and calibration_slot to -1 to skip. */
+    const char *calibration_local_path;
+    int         calibration_slot;
+
+    /* Acquisition mode.  continuous=1 (recommended for streaming)
+     * starts continuous acquisition once at open time so subsequent
+     * captures pay only the per-frame software-trigger cost.
+     * continuous=0 mimics ag-cam-tools' SingleFrame behaviour and
+     * restarts acquisition for every capture. */
+    int         continuous;
+
+    /* Verbose diagnostic prints during configuration. */
+    int         verbose;
+} AgOpenParams;
+
+typedef struct {
+    /* Raw Bayer planes for the captured frame.
+     *
+     * For stereo cameras (DualBayerRG8): left and right each point at
+     * a width*height single-eye plane, where width = sub-eye width
+     * after software binning and height = full frame height after
+     * software binning.
+     *
+     * For mono cameras (BayerRG8/Mono8): left points at the full
+     * width*height frame and right is NULL.
+     *
+     * Buffers are library-owned and remain valid until the next call
+     * to ag_camera_capture() or ag_camera_close(). */
+    unsigned char *left;
+    unsigned char *right;
+
+    /* Per-eye buffer dimensions (post-binning). */
+    unsigned int   width;
+    unsigned int   height;
+
+    /* Camera-reported frame id and timestamp in nanoseconds. */
+    unsigned long  frame_id;
+    unsigned long  timestamp_ns;
+} AgFrame;
+
+/*
+ * Open a camera and prepare it for capture.  Returns NULL on failure;
+ * call ag_camera_last_error() on a partially-initialised handle is
+ * not supported, so callers should rely on stderr diagnostics in that
+ * case.
+ */
+AgCamera *ag_camera_open(const AgOpenParams *params);
+
+/*
+ * Capture a single frame.  Returns 0 on success and fills *out;
+ * returns -1 on failure and stores a diagnostic string accessible
+ * via ag_camera_last_error().  *out is only valid on success.
+ */
+int ag_camera_capture(AgCamera *cam, AgFrame *out);
+
+/*
+ * Release a frame returned by ag_camera_capture().  In this revision
+ * the buffers are shared scratch space inside the AgCamera handle, so
+ * this call simply zeroes out *frame; the underlying memory is reused
+ * by the next capture.  Provided so future zero-copy implementations
+ * can be wired in without an ABI break.
+ */
+void ag_camera_release_frame(AgCamera *cam, AgFrame *frame);
+
+/*
+ * Stop acquisition (if running), free rectification tables, and tear
+ * down the camera handle.  Does not call arv_shutdown(), so further
+ * ag_camera_open() calls in the same process keep their discovery
+ * cache warm.
+ */
+void ag_camera_close(AgCamera *cam);
+
+/*
+ * Last error message captured on this handle, or "" if none.  The
+ * returned pointer is owned by the handle and remains valid until the
+ * next library call on the same handle.
+ */
+const char *ag_camera_last_error(AgCamera *cam);
+
+/*
+ * Sensor topology accessor: returns 1 for a dual-eye DualBayerRG8
+ * Lucid head, 0 for a monocular BayerRG8 / Mono8 camera.
+ */
+int ag_camera_is_stereo(const AgCamera *cam);
+
+/*
+ * Returns 1 if the captured planes still hold a valid Bayer mosaic
+ * (apply debayer to produce color), or 0 if the data should be treated
+ * as grayscale (e.g. when 2x2 averaging during binning destroyed the
+ * CFA pattern).  Constant after ag_camera_open() succeeds.
+ */
+int ag_camera_data_is_bayer(const AgCamera *cam);
+
+/*
+ * Borrowed pointers to the rectification remap tables loaded when
+ * calibration_local_path or calibration_slot was set in AgOpenParams.
+ * Return NULL if no calibration was requested.  Memory is owned by the
+ * AgCamera handle and freed by ag_camera_close().
+ */
+const AgRemapTable *ag_camera_get_remap_left(const AgCamera *cam);
+const AgRemapTable *ag_camera_get_remap_right(const AgCamera *cam);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AGRIPPA_H */

--- a/src/cmd_capture.c
+++ b/src/cmd_capture.c
@@ -101,13 +101,21 @@ capture_one_frame (const char *serial, const char *address,
         (void) tag_size_m;
 #endif
 
-        rc = write_split_bayer_pair (output_dir, base,
-                                     frame.left, frame.right,
-                                     frame.width, frame.height, enc,
-                                     ag_camera_data_is_bayer (cam) ? TRUE : FALSE,
-                                     NULL, NULL,
-                                     ov_left, n_ltags,
-                                     ov_right, n_rtags);
+        if (frame.channels == 3) {
+            /* ag_camera_capture() already applied gamma, debayer, and
+             * rectification — write the RGB24 planes directly. */
+            rc = write_split_rgb_pair (output_dir, base,
+                                       frame.left, frame.right,
+                                       frame.width, frame.height, enc);
+        } else {
+            rc = write_split_bayer_pair (output_dir, base,
+                                         frame.left, frame.right,
+                                         frame.width, frame.height, enc,
+                                         ag_camera_data_is_bayer (cam) ? TRUE : FALSE,
+                                         NULL, NULL,
+                                         ov_left, n_ltags,
+                                         ov_right, n_rtags);
+        }
     } else {
 #ifdef HAVE_APRILTAG
         if (tag_size_m > 0.0) {

--- a/src/cmd_capture.c
+++ b/src/cmd_capture.c
@@ -105,8 +105,7 @@ capture_one_frame (const char *serial, const char *address,
                                      frame.left, frame.right,
                                      frame.width, frame.height, enc,
                                      ag_camera_data_is_bayer (cam) ? TRUE : FALSE,
-                                     ag_camera_get_remap_left  (cam),
-                                     ag_camera_get_remap_right (cam),
+                                     NULL, NULL,
                                      ov_left, n_ltags,
                                      ov_right, n_rtags);
     } else {

--- a/src/cmd_capture.c
+++ b/src/cmd_capture.c
@@ -6,8 +6,14 @@
  * Lucid cameras like the Triton TRT016S).  With --burst N, captures N
  * frames in rapid succession via FrameBurstStart triggering — burst is
  * currently stereo-only.
+ *
+ * The single-frame path is implemented on top of libagrippa
+ * (src/agrippa.[ch]) so the library is dogfooded by the CLI; the
+ * burst path retains its own pipeline because libagrippa does not yet
+ * expose FrameBurstStart triggering.
  */
 
+#include "agrippa.h"
 #include "common.h"
 #include "apriltag_detect.h"
 #include "burst.h"
@@ -22,321 +28,118 @@
 #include <time.h>
 
 static int
-capture_one_frame (const char *device_id, const char *output_dir,
-                   const char *iface_ip, AgEncFormat enc,
+capture_one_frame (const char *serial, const char *address,
+                   const char *interface_name, const char *output_dir,
+                   AgEncFormat enc,
                    double exposure_us, double gain_db,
                    gboolean auto_expose, int packet_size, int binning,
                    gboolean verbose,
                    const AgCalibSource *calib_src,
                    double tag_size_m)
 {
-    GError *error = NULL;
-    ArvCamera *camera = arv_camera_new (device_id, &error);
-    if (!camera) {
-        fprintf (stderr, "error: %s\n",
-                 error ? error->message : "failed to open device");
-        g_clear_error (&error);
-        arv_shutdown ();
+    AgOpenParams params = {
+        .address                = address,
+        .serial                 = serial,
+        .interface_name         = interface_name,
+        .exposure_us            = exposure_us,
+        .gain_db                = gain_db,
+        .auto_expose            = auto_expose ? 1 : 0,
+        .binning                = binning,
+        .packet_size            = packet_size,
+        .calibration_local_path = calib_src->local_path,
+        .calibration_slot       = calib_src->slot,
+        .continuous             = 0,
+        .verbose                = verbose ? 1 : 0,
+    };
+
+    AgCamera *cam = ag_camera_open (&params);
+    if (!cam)
+        return EXIT_FAILURE;
+
+    AgFrame frame;
+    if (ag_camera_capture (cam, &frame) != 0) {
+        fprintf (stderr, "error: %s\n", ag_camera_last_error (cam));
+        ag_camera_close (cam);
         return EXIT_FAILURE;
     }
 
-    printf ("Connected.\n");
+    time_t now = time (NULL);
+    struct tm tm_now;
+    localtime_r (&now, &tm_now);
+    char base[64];
+    strftime (base, sizeof base, "capture_%Y%m%d_%H%M%S", &tm_now);
 
-    AgCameraConfig cfg;
-    if (camera_configure (camera, AG_MODE_SINGLE_FRAME,
-                          binning, exposure_us, gain_db, auto_expose,
-                          packet_size, iface_ip, verbose, &cfg) != EXIT_SUCCESS) {
-        g_object_unref (camera);
-        arv_shutdown ();
-        return EXIT_FAILURE;
-    }
-
-    ArvDevice *device = arv_camera_get_device (camera);
-
-    /* Load rectification remap tables if calibration was requested.
-     * Rectification requires a stereo calibration pipeline; mono
-     * cameras have nothing meaningful to rectify here. */
-    AgRemapTable *remap_left  = NULL;
-    AgRemapTable *remap_right = NULL;
-
-    if (calib_src->local_path || calib_src->slot >= 0) {
-        if (cfg.sensor_mode == AG_SENSOR_MONO) {
-            fprintf (stderr,
-                     "error: --calibration-local / --calibration-slot are "
-                     "stereo-only; not applicable to mono cameras\n");
-            g_object_unref (cfg.stream);
-            g_object_unref (camera);
-            arv_shutdown ();
-            return EXIT_FAILURE;
-        }
-        if (ag_calib_load (device, calib_src,
-                            &remap_left, &remap_right, NULL) != 0) {
-            g_object_unref (cfg.stream);
-            g_object_unref (camera);
-            arv_shutdown ();
-            return EXIT_FAILURE;
-        }
-
-        /* Validate remap dimensions against processed frame size. */
-        guint proc_sub_w = (cfg.frame_w / 2) / (guint) cfg.software_binning;
-        guint proc_h     = cfg.frame_h / (guint) cfg.software_binning;
-        if (remap_left->width != proc_sub_w ||
-            remap_left->height != proc_h) {
-            fprintf (stderr,
-                     "error: remap dimensions %ux%u do not match frame %ux%u\n",
-                     remap_left->width, remap_left->height,
-                     proc_sub_w, proc_h);
-            ag_remap_table_free (remap_left);
-            ag_remap_table_free (remap_right);
-            g_object_unref (cfg.stream);
-            g_object_unref (camera);
-            arv_shutdown ();
-            return EXIT_FAILURE;
-        }
-
-        printf ("Rectification maps loaded (%ux%u).\n",
-                remap_left->width, remap_left->height);
-    }
-
-    printf ("Starting acquisition...\n");
-    arv_camera_start_acquisition (camera, &error);
-    if (error) {
-        fprintf (stderr, "error: failed to start acquisition: %s\n",
-                 error->message);
-        g_clear_error (&error);
-        g_object_unref (cfg.stream);
-        g_object_unref (camera);
-        arv_shutdown ();
-        return EXIT_FAILURE;
-    }
-
-    if (auto_expose)
-        auto_expose_settle (camera, &cfg, 100000.0);
-
-    /* Wait for TriggerArmed. */
-    {
-        gboolean armed = FALSE;
-        int polls = 0;
-        while (!armed && polls < 100) {
-            GError *e = NULL;
-            armed = arv_device_get_boolean_feature_value (device, "TriggerArmed", &e);
-            g_clear_error (&e);
-            if (!armed) {
-                g_usleep (10000);
-                polls++;
-            }
-        }
-        if (!armed)
-            fprintf (stderr, "warn: TriggerArmed not set after %d polls, "
-                     "triggering anyway\n", polls);
-        else
-            printf ("  TriggerArmed after %d poll(s)\n", polls);
-    }
-
-    /* Fire software trigger. */
-    {
-        GError *e = NULL;
-        arv_device_execute_command (device, "TriggerSoftware", &e);
-        if (e) {
-            fprintf (stderr, "error: TriggerSoftware failed: %s\n", e->message);
-            g_clear_error (&e);
-        } else {
-            printf ("  TriggerSoftware executed\n");
-        }
-    }
-
-    ArvBuffer *buffer = NULL;
-    ArvBuffer *partial_buf = NULL;
-
-    for (int i = 0; i < 10; i++) {
-        ArvBuffer *b = arv_stream_timeout_pop_buffer (cfg.stream, 5000000);
-        if (!b) {
-            printf ("  attempt %d: no buffer\n", i);
-            continue;
-        }
-        ArvBufferStatus st = arv_buffer_get_status (b);
-        if (st == ARV_BUFFER_STATUS_SUCCESS) {
-            if (partial_buf) {
-                arv_stream_push_buffer (cfg.stream, partial_buf);
-                partial_buf = NULL;
-            }
-            buffer = b;
-            break;
-        }
-
-        size_t bdata_sz = 0;
-        arv_buffer_get_data (b, &bdata_sz);
-        ArvBufferPayloadType bpt = arv_buffer_get_payload_type (b);
-        guint bw = 0, bh = 0;
-        if (bdata_sz > 0 &&
-            (bpt == ARV_BUFFER_PAYLOAD_TYPE_IMAGE ||
-             bpt == ARV_BUFFER_PAYLOAD_TYPE_EXTENDED_CHUNK_DATA)) {
-            bw = arv_buffer_get_image_width (b);
-            bh = arv_buffer_get_image_height (b);
-        }
-        printf ("  attempt %d: status=%d  payload=0x%x  frame_id=%" G_GUINT64_FORMAT
-                "  recv=%zu bytes  %ux%u\n",
-                i, (int) st, (unsigned) bpt,
-                arv_buffer_get_frame_id (b), bdata_sz, bw, bh);
-
-        if (partial_buf)
-            arv_stream_push_buffer (cfg.stream, partial_buf);
-        partial_buf = b;
-    }
-
-    if (!buffer) {
-        fprintf (stderr, "error: timeout waiting for frame\n");
-
-        /* Save partial data for debugging. */
-        if (partial_buf) {
-            size_t ps = 0;
-            const guint8 *pd = (const guint8 *) arv_buffer_get_data (partial_buf, &ps);
-            ArvBufferPayloadType ppt = arv_buffer_get_payload_type (partial_buf);
-            guint pw = 0, ph = 0;
-            if (ps > 0 &&
-                (ppt == ARV_BUFFER_PAYLOAD_TYPE_IMAGE ||
-                 ppt == ARV_BUFFER_PAYLOAD_TYPE_EXTENDED_CHUNK_DATA)) {
-                pw = arv_buffer_get_image_width (partial_buf);
-                ph = arv_buffer_get_image_height (partial_buf);
-            }
-            fprintf (stderr, "  partial frame: %ux%u  %zu bytes received\n", pw, ph, ps);
-            if (pd && pw > 0 && ph > 0 && ps >= (size_t) pw * ph) {
-                char *ppath = g_build_filename (output_dir, "partial_frame.pgm", NULL);
-                if (write_pgm (ppath, pd, pw, ph) == EXIT_SUCCESS)
-                    fprintf (stderr, "  partial frame saved -> %s\n", ppath);
-                g_free (ppath);
-            }
-            arv_stream_push_buffer (cfg.stream, partial_buf);
-        }
-
-        if (ARV_IS_GV_STREAM (cfg.stream)) {
-            guint64 n_completed = 0, n_failures = 0, n_underruns = 0;
-            arv_stream_get_statistics (cfg.stream, &n_completed, &n_failures, &n_underruns);
-            fprintf (stderr, "  stream stats: completed=%" G_GUINT64_FORMAT
-                     " failures=%" G_GUINT64_FORMAT
-                     " underruns=%" G_GUINT64_FORMAT "\n",
-                     n_completed, n_failures, n_underruns);
-
-            guint64 resent = 0, missing = 0;
-            arv_gv_stream_get_statistics (ARV_GV_STREAM (cfg.stream), &resent, &missing);
-            fprintf (stderr, "  gv stats:     resent=%" G_GUINT64_FORMAT
-                     " missing=%" G_GUINT64_FORMAT "\n", resent, missing);
-        }
-        arv_camera_stop_acquisition (camera, NULL);
-        g_object_unref (cfg.stream);
-        g_object_unref (camera);
-        arv_shutdown ();
-        return EXIT_FAILURE;
-    }
-
-    size_t data_size = 0;
-    const guint8 *data = arv_buffer_get_data (buffer, &data_size);
-    guint width  = arv_buffer_get_image_width (buffer);
-    guint height = arv_buffer_get_image_height (buffer);
-    size_t needed = (size_t) width * (size_t) height;
-
-    int rc = EXIT_FAILURE;
-    if (!data || data_size < needed) {
-        fprintf (stderr, "error: unsupported frame buffer size (%zu bytes for %ux%u)\n",
-                 data_size, width, height);
-    } else {
-        time_t now = time (NULL);
-        struct tm tm_now;
-        localtime_r (&now, &tm_now);
-        char base[64];
-        strftime (base, sizeof base, "capture_%Y%m%d_%H%M%S", &tm_now);
-
-        const char *pixel_format = arv_device_get_string_feature_value (
-                                       device, "PixelFormat", NULL);
-        if (pixel_format && strcmp (pixel_format, "DualBayerRG8") == 0) {
-            const void *ov_left = NULL, *ov_right = NULL;
-            int n_ltags = 0, n_rtags = 0;
+    int rc;
+    if (ag_camera_is_stereo (cam)) {
+        const void *ov_left = NULL, *ov_right = NULL;
+        int n_ltags = 0, n_rtags = 0;
 
 #ifdef HAVE_APRILTAG
-            AgTagOverlay left_ov[AG_MAX_TAG_OVERLAYS];
-            AgTagOverlay right_ov[AG_MAX_TAG_OVERLAYS];
-            if (tag_size_m > 0.0) {
-                guint sub_w = (width / 2) / (guint) cfg.software_binning;
-                guint sub_h = height / (guint) cfg.software_binning;
-                size_t eye_n = (size_t) sub_w * (size_t) sub_h;
-                guint8 *tag_left  = g_malloc (eye_n);
-                guint8 *tag_right = g_malloc (eye_n);
-                extract_dual_bayer_eyes (data, width, height,
-                                          cfg.software_binning,
-                                          tag_left, tag_right);
+        AgTagOverlay left_ov[AG_MAX_TAG_OVERLAYS];
+        AgTagOverlay right_ov[AG_MAX_TAG_OVERLAYS];
+        if (tag_size_m > 0.0) {
+            AgApriltagContext *at_ctx = ag_apriltag_create ();
+            double fx, fy, cx, cy;
+            ag_apriltag_estimate_intrinsics (frame.width, frame.height,
+                                             &fx, &fy, &cx, &cy);
 
-                AgApriltagContext *at_ctx = ag_apriltag_create ();
-                double fx, fy, cx, cy;
-                ag_apriltag_estimate_intrinsics (sub_w, sub_h,
-                                                 &fx, &fy, &cx, &cy);
+            n_ltags = ag_detect_tags_and_pose (at_ctx->detector,
+                         frame.left, frame.width, frame.height, tag_size_m,
+                         fx, fy, cx, cy, 0, "left",
+                         left_ov, AG_MAX_TAG_OVERLAYS, FALSE);
+            n_rtags = ag_detect_tags_and_pose (at_ctx->detector,
+                         frame.right, frame.width, frame.height, tag_size_m,
+                         fx, fy, cx, cy, 0, "right",
+                         right_ov, AG_MAX_TAG_OVERLAYS, FALSE);
 
-                n_ltags = ag_detect_tags_and_pose (at_ctx->detector,
-                             tag_left, sub_w, sub_h, tag_size_m,
-                             fx, fy, cx, cy, 0, "left",
-                             left_ov, AG_MAX_TAG_OVERLAYS, FALSE);
-                n_rtags = ag_detect_tags_and_pose (at_ctx->detector,
-                             tag_right, sub_w, sub_h, tag_size_m,
-                             fx, fy, cx, cy, 0, "right",
-                             right_ov, AG_MAX_TAG_OVERLAYS, FALSE);
+            ov_left  = left_ov;
+            ov_right = right_ov;
 
-                ov_left  = left_ov;
-                ov_right = right_ov;
-
-                ag_apriltag_destroy (at_ctx);
-                g_free (tag_left);
-                g_free (tag_right);
-            }
+            ag_apriltag_destroy (at_ctx);
+        }
 #else
-            (void) tag_size_m;
+        (void) tag_size_m;
 #endif
-            rc = write_dual_bayer_pair (output_dir, base, data, width, height,
-                                        enc, cfg.software_binning,
-                                        cfg.data_is_bayer,
-                                        remap_left, remap_right,
-                                        ov_left, n_ltags,
-                                        ov_right, n_rtags);
-        } else {
+
+        rc = write_split_bayer_pair (output_dir, base,
+                                     frame.left, frame.right,
+                                     frame.width, frame.height, enc,
+                                     ag_camera_data_is_bayer (cam) ? TRUE : FALSE,
+                                     ag_camera_get_remap_left  (cam),
+                                     ag_camera_get_remap_right (cam),
+                                     ov_left, n_ltags,
+                                     ov_right, n_rtags);
+    } else {
 #ifdef HAVE_APRILTAG
-            /* Mono path: optional tag detection.  Tags are logged via
-             * ag_detect_tags_and_pose; overlay rendering into the saved
-             * image is not yet implemented for mono. */
-            if (tag_size_m > 0.0) {
-                guint sub_w = width  / (guint) cfg.software_binning;
-                guint sub_h = height / (guint) cfg.software_binning;
-                AgApriltagContext *at_ctx = ag_apriltag_create ();
-                double fx, fy, cx, cy;
-                ag_apriltag_estimate_intrinsics (sub_w, sub_h,
-                                                 &fx, &fy, &cx, &cy);
-                AgTagOverlay tags[AG_MAX_TAG_OVERLAYS];
-                ag_detect_tags_and_pose (at_ctx->detector, data,
-                                         sub_w, sub_h, tag_size_m,
-                                         fx, fy, cx, cy, 0, "mono",
-                                         tags, AG_MAX_TAG_OVERLAYS, FALSE);
-                ag_apriltag_destroy (at_ctx);
-            }
-#endif
-            const char *ext = (enc == AG_ENC_PNG) ? "png"
-                            : (enc == AG_ENC_JPG) ? "jpg" : "pgm";
-            char *name = g_strdup_printf ("%s.%s", base, ext);
-            char *path = g_build_filename (output_dir, name, NULL);
-            if (enc == AG_ENC_PGM)
-                rc = write_pgm (path, data, width, height);
-            else
-                rc = write_color_image (enc, path, data, width, height);
-            printf ("Saved: %s  (%ux%u, %s)\n", path, width, height,
-                    pixel_format ? pixel_format : "?");
-            g_free (name);
-            g_free (path);
+        if (tag_size_m > 0.0) {
+            AgApriltagContext *at_ctx = ag_apriltag_create ();
+            double fx, fy, cx, cy;
+            ag_apriltag_estimate_intrinsics (frame.width, frame.height,
+                                             &fx, &fy, &cx, &cy);
+            AgTagOverlay tags[AG_MAX_TAG_OVERLAYS];
+            ag_detect_tags_and_pose (at_ctx->detector, frame.left,
+                                     frame.width, frame.height, tag_size_m,
+                                     fx, fy, cx, cy, 0, "mono",
+                                     tags, AG_MAX_TAG_OVERLAYS, FALSE);
+            ag_apriltag_destroy (at_ctx);
         }
+#endif
+        const char *ext = (enc == AG_ENC_PNG) ? "png"
+                        : (enc == AG_ENC_JPG) ? "jpg" : "pgm";
+        char *name = g_strdup_printf ("%s.%s", base, ext);
+        char *path = g_build_filename (output_dir, name, NULL);
+        if (enc == AG_ENC_PGM)
+            rc = write_pgm (path, frame.left, frame.width, frame.height);
+        else
+            rc = write_color_image (enc, path, frame.left,
+                                    frame.width, frame.height);
+        printf ("Saved: %s  (%ux%u)\n", path, frame.width, frame.height);
+        g_free (name);
+        g_free (path);
     }
 
-    arv_stream_push_buffer (cfg.stream, buffer);
-    arv_camera_stop_acquisition (camera, NULL);
-    ag_remap_table_free (remap_left);
-    ag_remap_table_free (remap_right);
-    g_object_unref (cfg.stream);
-    g_object_unref (camera);
-    arv_shutdown ();
+    ag_camera_release_frame (cam, &frame);
+    ag_camera_close (cam);
     return rc;
 }
 
@@ -679,12 +482,6 @@ cmd_capture (int argc, char *argv[], arg_dstr_t res, void *ctx)
     const char *opt_interface = interface->count  ? interface->sval[0] : NULL;
     const char *opt_output    = output->sval[0];
 
-    const char *iface_ip = NULL;
-    if (opt_interface) {
-        iface_ip = setup_interface (opt_interface);
-        if (!iface_ip) { exitcode = EXIT_FAILURE; goto done; }
-    }
-
     if (g_mkdir_with_parents (opt_output, 0755) != 0) {
         arg_dstr_catf (res, "error: cannot create output directory '%s'\n",
                        opt_output);
@@ -692,25 +489,33 @@ cmd_capture (int argc, char *argv[], arg_dstr_t res, void *ctx)
         goto done;
     }
 
-    char *device_id = resolve_device (opt_serial, opt_address,
-                                       opt_interface, TRUE);
-    if (!device_id) { exitcode = EXIT_FAILURE; goto done; }
-
     int pkt_sz = pkt_size->count ? pkt_size->ival[0] : 0;
 
-    if (burst_count > 0)
+    if (burst_count > 0) {
+        /* Burst path still resolves the device itself and uses raw
+         * Aravis APIs — libagrippa does not yet support FrameBurstStart. */
+        const char *iface_ip = NULL;
+        if (opt_interface) {
+            iface_ip = setup_interface (opt_interface);
+            if (!iface_ip) { exitcode = EXIT_FAILURE; goto done; }
+        }
+        char *device_id = resolve_device (opt_serial, opt_address,
+                                           opt_interface, TRUE);
+        if (!device_id) { exitcode = EXIT_FAILURE; goto done; }
         exitcode = capture_burst_frames (device_id, opt_output, iface_ip,
                                           enc, exposure_us, gain_db,
                                           do_auto_expose, pkt_sz, binning,
                                           verbose->count > 0,
                                           &calib_src, burst_count,
                                           tag_size_m);
-    else
-        exitcode = capture_one_frame (device_id, opt_output, iface_ip, enc,
+        g_free (device_id);
+    } else {
+        exitcode = capture_one_frame (opt_serial, opt_address, opt_interface,
+                                       opt_output, enc,
                                        exposure_us, gain_db, do_auto_expose,
                                        pkt_sz, binning, verbose->count > 0,
                                        &calib_src, tag_size_m);
-    g_free (device_id);
+    }
 
 done:
     arg_freetable (argtable, sizeof argtable / sizeof argtable[0]);

--- a/src/image.c
+++ b/src/image.c
@@ -172,49 +172,24 @@ write_rgb_image_raw (AgEncFormat enc, const char *path,
 }
 
 int
-write_dual_bayer_pair (const char *output_dir,
-                       const char *basename_no_ext,
-                       const guint8 *interleaved,
-                       guint width, guint height,
-                       AgEncFormat enc,
-                       int software_binning,
-                       gboolean data_is_bayer,
-                       const AgRemapTable *remap_left,
-                       const AgRemapTable *remap_right,
-                       const void *left_tags, int n_left_tags,
-                       const void *right_tags, int n_right_tags)
+write_split_bayer_pair (const char *output_dir,
+                        const char *basename_no_ext,
+                        guint8 *left, guint8 *right,
+                        guint width, guint height,
+                        AgEncFormat enc,
+                        gboolean data_is_bayer,
+                        const AgRemapTable *remap_left,
+                        const AgRemapTable *remap_right,
+                        const void *left_tags, int n_left_tags,
+                        const void *right_tags, int n_right_tags)
 {
 #ifndef HAVE_APRILTAG
     (void) left_tags;  (void) n_left_tags;
     (void) right_tags; (void) n_right_tags;
 #endif
-    if (width % 2 != 0) {
-        fprintf (stderr, "error: DualBayer frame width must be even, got %u\n",
-                 width);
-        return EXIT_FAILURE;
-    }
-
-    guint src_sub_w = width / 2;
-    guint dst_w = src_sub_w;
+    size_t eye_n = (size_t) width * (size_t) height;
+    guint dst_w = width;
     guint dst_h = height;
-
-    if (software_binning > 1) {
-        dst_w = src_sub_w / 2;
-        dst_h = height / 2;
-    }
-
-    size_t eye_n = (size_t) dst_w * (size_t) dst_h;
-    guint8 *left  = g_malloc (eye_n);
-    guint8 *right = g_malloc (eye_n);
-    if (!left || !right) {
-        g_free (left);
-        g_free (right);
-        fprintf (stderr, "error: out of memory while extracting DualBayer frame\n");
-        return EXIT_FAILURE;
-    }
-
-    extract_dual_bayer_eyes (interleaved, width, height, software_binning,
-                             left, right);
 
     const char *ext = (enc == AG_ENC_PNG) ? "png"
                     : (enc == AG_ENC_JPG) ? "jpg" : "pgm";
@@ -326,9 +301,59 @@ write_dual_bayer_pair (const char *output_dir,
     g_free (right_name);
     g_free (left_path);
     g_free (right_path);
-    g_free (left);
-    g_free (right);
 
     return (rc_left == EXIT_SUCCESS && rc_right == EXIT_SUCCESS)
            ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+int
+write_dual_bayer_pair (const char *output_dir,
+                       const char *basename_no_ext,
+                       const guint8 *interleaved,
+                       guint width, guint height,
+                       AgEncFormat enc,
+                       int software_binning,
+                       gboolean data_is_bayer,
+                       const AgRemapTable *remap_left,
+                       const AgRemapTable *remap_right,
+                       const void *left_tags, int n_left_tags,
+                       const void *right_tags, int n_right_tags)
+{
+    if (width % 2 != 0) {
+        fprintf (stderr, "error: DualBayer frame width must be even, got %u\n",
+                 width);
+        return EXIT_FAILURE;
+    }
+
+    guint src_sub_w = width / 2;
+    guint dst_w = src_sub_w;
+    guint dst_h = height;
+
+    if (software_binning > 1) {
+        dst_w = src_sub_w / 2;
+        dst_h = height / 2;
+    }
+
+    size_t eye_n = (size_t) dst_w * (size_t) dst_h;
+    guint8 *left  = g_malloc (eye_n);
+    guint8 *right = g_malloc (eye_n);
+    if (!left || !right) {
+        g_free (left);
+        g_free (right);
+        fprintf (stderr, "error: out of memory while extracting DualBayer frame\n");
+        return EXIT_FAILURE;
+    }
+
+    extract_dual_bayer_eyes (interleaved, width, height, software_binning,
+                             left, right);
+
+    int rc = write_split_bayer_pair (output_dir, basename_no_ext,
+                                      left, right, dst_w, dst_h, enc,
+                                      data_is_bayer,
+                                      remap_left, remap_right,
+                                      left_tags, n_left_tags,
+                                      right_tags, n_right_tags);
+    g_free (left);
+    g_free (right);
+    return rc;
 }

--- a/src/image.c
+++ b/src/image.c
@@ -149,10 +149,6 @@ write_rgba_png (const char *path,
     return EXIT_SUCCESS;
 }
 
-/*
- * Write a single rectified image (RGB24 data already gamma-corrected,
- * debayered, and remapped).
- */
 static int
 write_rgb_image_raw (AgEncFormat enc, const char *path,
                      const guint8 *rgb, guint width, guint height)
@@ -169,6 +165,52 @@ write_rgb_image_raw (AgEncFormat enc, const char *path,
         return EXIT_FAILURE;
     }
     return EXIT_SUCCESS;
+}
+
+int
+write_split_rgb_pair (const char *output_dir,
+                      const char *basename_no_ext,
+                      const guint8 *left, const guint8 *right,
+                      guint width, guint height,
+                      AgEncFormat enc)
+{
+    const char *ext = (enc == AG_ENC_PNG) ? "png"
+                    : (enc == AG_ENC_JPG) ? "jpg" : "pgm";
+    char *left_name  = g_strdup_printf ("%s_left.%s",  basename_no_ext, ext);
+    char *right_name = g_strdup_printf ("%s_right.%s", basename_no_ext, ext);
+    char *left_path  = g_build_filename (output_dir, left_name,  NULL);
+    char *right_path = g_build_filename (output_dir, right_name, NULL);
+
+    int rc_left, rc_right;
+
+    if (enc == AG_ENC_PGM) {
+        /* PGM: convert RGB to grayscale first. */
+        size_t n = (size_t) width * (size_t) height;
+        guint8 *gray_l = g_malloc (n);
+        guint8 *gray_r = g_malloc (n);
+        rgb_to_gray (left,  gray_l, (uint32_t) n);
+        rgb_to_gray (right, gray_r, (uint32_t) n);
+        rc_left  = write_pgm (left_path,  gray_l, width, height);
+        rc_right = write_pgm (right_path, gray_r, width, height);
+        g_free (gray_l);
+        g_free (gray_r);
+    } else {
+        rc_left  = write_rgb_image_raw (enc, left_path,  left,  width, height);
+        rc_right = write_rgb_image_raw (enc, right_path, right, width, height);
+    }
+
+    if (rc_left == EXIT_SUCCESS && rc_right == EXIT_SUCCESS) {
+        printf ("Saved: %s  (%ux%u, rectified left)\n",  left_path,  width, height);
+        printf ("Saved: %s  (%ux%u, rectified right)\n", right_path, width, height);
+    }
+
+    g_free (left_name);
+    g_free (right_name);
+    g_free (left_path);
+    g_free (right_path);
+
+    return (rc_left == EXIT_SUCCESS && rc_right == EXIT_SUCCESS)
+           ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
 int

--- a/src/image.h
+++ b/src/image.h
@@ -74,6 +74,18 @@ int write_dual_bayer_pair (const char *output_dir,
  * Semantics for data_is_bayer, remap_left/right, and the tag overlays
  * match write_dual_bayer_pair().
  */
+/*
+ * Write a stereo pair from already-processed RGB24 data (e.g. the
+ * gamma-corrected, debayered, rectified planes returned by
+ * ag_camera_capture() when calibration is configured).
+ * left and right must each be width*height*3 bytes.
+ */
+int write_split_rgb_pair (const char *output_dir,
+                          const char *basename_no_ext,
+                          const guint8 *left, const guint8 *right,
+                          guint width, guint height,
+                          AgEncFormat enc);
+
 int write_split_bayer_pair (const char *output_dir,
                             const char *basename_no_ext,
                             guint8 *left, guint8 *right,

--- a/src/image.h
+++ b/src/image.h
@@ -63,4 +63,26 @@ int write_dual_bayer_pair (const char *output_dir,
                            const void *left_tags, int n_left_tags,
                            const void *right_tags, int n_right_tags);
 
+/*
+ * Encode an already-split stereo pair.
+ *
+ * left and right must each be width*height bytes at the per-eye
+ * resolution (i.e. software binning has already been applied).  The
+ * function may mutate left/right in place (gamma LUT, etc.); callers
+ * that need to preserve the original data must copy first.
+ *
+ * Semantics for data_is_bayer, remap_left/right, and the tag overlays
+ * match write_dual_bayer_pair().
+ */
+int write_split_bayer_pair (const char *output_dir,
+                            const char *basename_no_ext,
+                            guint8 *left, guint8 *right,
+                            guint width, guint height,
+                            AgEncFormat enc,
+                            gboolean data_is_bayer,
+                            const AgRemapTable *remap_left,
+                            const AgRemapTable *remap_right,
+                            const void *left_tags, int n_left_tags,
+                            const void *right_tags, int n_right_tags);
+
 #endif /* AG_IMAGE_H */

--- a/src/npy.c
+++ b/src/npy.c
@@ -2,6 +2,7 @@
  * npy.c — minimal NumPy .npy v1.0 parser for float64 arrays
  */
 
+#define _GNU_SOURCE
 #include "npy.h"
 
 #include <stdio.h>

--- a/src/npy.h
+++ b/src/npy.h
@@ -11,6 +11,7 @@
 
 #include <glib.h>
 #include <stddef.h>
+#include <stdint.h>
 
 typedef struct {
     int      ndim;


### PR DESCRIPTION
Added a capture API to be able to create ctypes bindings for the Agrippa stereo camera library

Example Python usage:
```
    def capture(self) -> tuple[np.ndarray, np.ndarray | None]:
        if self._handle is None:
            raise StereoCameraError("camera is not open")
        frame = _AgFrame()
        rc = _lib.ag_camera_capture(self._handle, ctypes.byref(frame))
```