### PR TITLE
AprilGrid whole-board detection and an on-box stereo + hand-eye solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,14 @@ site/
 
 # Scratch images
 *.png
+
+# Capture and preview artefacts. `stream`, `depth-preview` and `capture` write these
+# into the working directory by default, so they accumulate during any bench session
+# and are easy to commit by accident. Ignored, not deleted.
+*.mp4
+*.pgm
+depth_preview_*
+stream_*
+capture_*
+inspection_demo/
+tending_captures/

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ ifneq ($(OPENCV_LIBS),)
   CFLAGS   += $(OPENCV_CFLAGS) -DHAVE_OPENCV=1
   LIBS     += $(OPENCV_LIBS)
   CXX_SRCS += $(SRCDIR)/stereo_sgbm.cpp
+  CXX_SRCS += $(SRCDIR)/aprilgrid.cpp
   CXX_OBJS  = $(patsubst $(SRCDIR)/%.cpp,$(BINDIR)/%.o,$(CXX_SRCS))
   # C++ standard library required when linking a mixed C/C++ binary
   LIBS     += -lstdc++

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,7 @@ else ifneq ($(wildcard $(VENDORDIR)/apriltag/apriltag.h),)
   APRILTAG_SRCS = $(APRILTAG_DIR)/apriltag.c \
                   $(APRILTAG_DIR)/apriltag_quad_thresh.c \
                   $(APRILTAG_DIR)/apriltag_pose.c \
-                  $(APRILTAG_DIR)/tagStandard52h13.c \
-                  $(APRILTAG_DIR)/tagStandard41h12.c \
+                  $(wildcard $(APRILTAG_DIR)/tag*.c) \
                   $(wildcard $(APRILTAG_DIR)/common/*.c)
   APRILTAG_OBJS = $(patsubst $(APRILTAG_DIR)/%.c,$(BINDIR)/apriltag/%.o,$(APRILTAG_SRCS))
 endif

--- a/Makefile
+++ b/Makefile
@@ -92,15 +92,28 @@ OPENCV_CFLAGS := $(shell pkg-config --cflags opencv4 2>/dev/null)
 OPENCV_LIBS   := $(shell pkg-config --libs   opencv4 2>/dev/null)
 
 ifneq ($(OPENCV_LIBS),)
-  CFLAGS   += $(OPENCV_CFLAGS) -DHAVE_OPENCV=1
-  LIBS     += $(OPENCV_LIBS)
-  CXX_SRCS += $(SRCDIR)/stereo_sgbm.cpp
+  LIBS     += $(OPENCV_LIBS) -lstdc++
+
+  # calib-solve needs only core+imgproc+calib3d, which distros package plainly:
+  # 3 packages, +11 MB, no contrib.
+  CFLAGS   += $(OPENCV_CFLAGS) -DHAVE_OPENCV_CALIB=1
   CXX_SRCS += $(SRCDIR)/aprilgrid.cpp
   CXX_SRCS += $(SRCDIR)/calib_solve.cpp
   CXX_SRCS += $(SRCDIR)/cmd_calib_solve.cpp
+
+  # StereoSGBM's WLS filter needs cv::ximgproc, which lives in opencv_contrib -- a
+  # far bigger ask than the solver's three modules (on Ubuntu 22.04 contrib drags
+  # GDAL, GTK-3, x265 and GDCM: 279 packages, +314 MB). Gate the depth backend on
+  # the header actually being there, so an OpenCV without contrib still builds and
+  # still gets calib-solve. HAVE_OPENCV keeps its existing meaning throughout
+  # stereo_common.c / stereo.h / cmd_depth_preview.c: the SGBM backend.
+  OPENCV_INC := $(firstword $(patsubst -I%,%,$(filter -I%,$(OPENCV_CFLAGS))))
+  ifneq ($(wildcard $(OPENCV_INC)/opencv2/ximgproc/disparity_filter.hpp),)
+    CFLAGS   += -DHAVE_OPENCV=1
+    CXX_SRCS += $(SRCDIR)/stereo_sgbm.cpp
+  endif
+
   CXX_OBJS  = $(patsubst $(SRCDIR)/%.cpp,$(BINDIR)/%.o,$(CXX_SRCS))
-  # C++ standard library required when linking a mixed C/C++ binary
-  LIBS     += -lstdc++
 endif
 
 # --- ONNX Runtime: optional, provides in-process neural stereo backend ---

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,8 @@ ifneq ($(OPENCV_LIBS),)
   LIBS     += $(OPENCV_LIBS)
   CXX_SRCS += $(SRCDIR)/stereo_sgbm.cpp
   CXX_SRCS += $(SRCDIR)/aprilgrid.cpp
+  CXX_SRCS += $(SRCDIR)/calib_solve.cpp
+  CXX_SRCS += $(SRCDIR)/cmd_calib_solve.cpp
   CXX_OBJS  = $(patsubst $(SRCDIR)/%.cpp,$(BINDIR)/%.o,$(CXX_SRCS))
   # C++ standard library required when linking a mixed C/C++ binary
   LIBS     += -lstdc++

--- a/src/aprilgrid.cpp
+++ b/src/aprilgrid.cpp
@@ -1,0 +1,431 @@
+/* aprilgrid.cpp — see aprilgrid.hpp. */
+
+#ifdef HAVE_OPENCV
+
+#include "aprilgrid.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <opencv2/calib3d.hpp>
+#include <opencv2/imgproc.hpp>
+extern "C" {
+#include <apriltag.h>
+#include <tag36h11.h>
+}
+
+namespace {
+
+const int DATA_CELLS   = 6;    /* tag36h11 payload is 6x6 */
+const int BORDER_CELLS = 2;    /* Kalibr AprilGrid black border; apriltag3 assumes 1 */
+
+const int    kGuidedPasses = 4;    /* each accepted tag improves its neighbours */
+const double kMinContrast  = 25.0; /* data-cell span below which a read is junk */
+const int    kMaxHamming   = 2;
+const int    kNeighbours   = 6;
+const int    kCellPx       = 12;   /* warp resolution per cell */
+const double kMinPerimeter = 40.0; /* contour smaller than this cannot be a tag */
+const double kMinArea      = 200.0;
+const double kSeedTolPx    = 4.0;  /* neighbours place a good seed to well under 1 px */
+
+/* Plain-pass sweep. Which adaptive-threshold window works depends on how big the tags
+ * land in the frame, and corner refinement helps on some frames and loses tags on
+ * others, so try the grid and keep whichever reads most. */
+const int kThreshWindows[4][3] = {{3, 23, 10}, {11, 51, 10}, {15, 75, 10}, {21, 101, 20}};
+
+/*
+ * The 6x6 data matrix tag36h11 holds for each id, straight out of libapriltag's own
+ * code table.
+ *
+ * Previously this rendered an ArUco marker at borderBits=1 and cropped it, which is
+ * what the Python does because cv2 exposes no bit table. In C the table IS the
+ * dependency we already have: tf->codes[id] with tf->bit_x/bit_y, and stock tag36h11
+ * puts its 36 payload bits at 1..6 inside an 8-wide border box. Verified against tags
+ * an independent decoder had already read: hamming 0, every tag.
+ */
+const std::vector<cv::Mat> &expected_bits_table ()
+{
+    static std::vector<cv::Mat> table;
+    if (!table.empty ())
+        return table;
+    apriltag_family_t *tf = tag36h11_create ();
+    table.resize (tf->ncodes);
+    for (uint32_t id = 0; id < tf->ncodes; id++) {
+        cv::Mat b (DATA_CELLS, DATA_CELLS, CV_8UC1, cv::Scalar (0));
+        const uint64_t code = tf->codes[id];
+        for (uint32_t i = 0; i < tf->nbits; i++)
+            b.at<uchar> (static_cast<int> (tf->bit_y[i]) - 1,
+                         static_cast<int> (tf->bit_x[i]) - 1) =
+                (uchar) ((code >> (tf->nbits - 1 - i)) & 1ULL);
+        /* 180 degrees. libapriltag's payload convention is rot90(k=2) from the one the
+         * board is printed in -- verified over all 70 ids: same codes, no id
+         * permutation, a constant two-quarter-turn apart. The guided pass would absorb
+         * this (it matches over all four rotations) but the seed pass must not: it pins
+         * each seed's winding by a DIRECT comparison, and a seed wound 180 degrees out
+         * makes the local homography fit a lattice half a tag off. Measured: every one
+         * of 70 tags came back cyclically shifted by 2, and 12.7 px from the corner it
+         * should be. */
+        cv::Mat r;
+        cv::flip (b, r, -1);
+        table[id] = r;
+    }
+    tag36h11_destroy (tf);
+    return table;
+}
+
+const cv::Mat &expected_bits (int tag_id) { return expected_bits_table ()[tag_id]; }
+
+cv::Point2f centroid (const std::vector<cv::Point2f> &p)
+{
+    cv::Point2f c (0.f, 0.f);
+    for (size_t i = 0; i < p.size (); i++) c += p[i];
+    return c * (1.0f / static_cast<float> (p.size ()));
+}
+
+/*
+ * Subpixel corners. Deliberately UNCLAMPED.
+ *
+ * A leash on how far a corner may travel was tried and made things worse: it fires on
+ * some frames and not others, so the same corner lands in two different places and the
+ * frame-to-frame spread goes bimodal (p90 0.03 px -> 0.85 px over 6 static frames). A
+ * few edge-tag corners do jump a cell when cornerSubPix latches onto the diagonally
+ * touching gap square; leave those to the solver's outlier rejection rather than
+ * making every corner less repeatable.
+ */
+void refine (const cv::Mat &gray, std::vector<cv::Point2f> &quad)
+{
+    cv::cornerSubPix (gray, quad, cv::Size (5, 5), cv::Size (-1, -1),
+                      cv::TermCriteria (cv::TermCriteria::EPS + cv::TermCriteria::MAX_ITER,
+                                        30, 0.01));
+}
+
+/* Warp the tag's black square flat and read its data cells. Returns the contrast
+ * (span between darkest and brightest cell); `bits` gets the 6x6 payload. */
+double read_cells (const cv::Mat &gray, const std::vector<cv::Point2f> &quad, cv::Mat &bits)
+{
+    const int px = kCellPx;
+    const int side = (DATA_CELLS + 2 * BORDER_CELLS) * px;
+    std::vector<cv::Point2f> target;
+    target.push_back (cv::Point2f (0, 0));
+    target.push_back (cv::Point2f (side, 0));
+    target.push_back (cv::Point2f (side, side));
+    target.push_back (cv::Point2f (0, side));
+
+    cv::Mat warp;
+    cv::warpPerspective (gray, warp, cv::getPerspectiveTransform (quad, target),
+                         cv::Size (side, side));
+
+    cv::Mat vals (DATA_CELLS, DATA_CELLS, CV_64FC1);
+    double lo = std::numeric_limits<double>::infinity (), hi = -lo;
+    for (int r = 0; r < DATA_CELLS; r++)
+        for (int c = 0; c < DATA_CELLS; c++) {
+            const int y = (r + BORDER_CELLS) * px, x = (c + BORDER_CELLS) * px;
+            const double v = cv::mean (warp (cv::Rect (x + px / 4, y + px / 4,
+                                                       px / 2, px / 2)))[0];
+            vals.at<double> (r, c) = v;
+            lo = std::min (lo, v);
+            hi = std::max (hi, v);
+        }
+    const double thresh = 0.5 * (lo + hi);
+    bits.create (DATA_CELLS, DATA_CELLS, CV_8UC1);
+    for (int r = 0; r < DATA_CELLS; r++)
+        for (int c = 0; c < DATA_CELLS; c++)
+            bits.at<uchar> (r, c) = vals.at<double> (r, c) > thresh ? 1 : 0;
+    return hi - lo;
+}
+
+/* np.rot90 with k quarter-turns, counter-clockwise, on a square 8-bit matrix. */
+cv::Mat rot90 (const cv::Mat &m, int k)
+{
+    cv::Mat out = m.clone ();
+    for (int i = 0; i < k; i++) {
+        cv::Mat t;
+        cv::transpose (out, t);
+        cv::flip (t, out, 0);          /* transpose + flip vertical == CCW */
+    }
+    return out;
+}
+
+/* Best match over the four rotations -- a predicted quad's winding is arbitrary. */
+int hamming (const cv::Mat &bits, const cv::Mat &want)
+{
+    int best = DATA_CELLS * DATA_CELLS + 1;
+    for (int k = 0; k < 4; k++) {
+        const cv::Mat r = rot90 (bits, k);
+        int d = 0;
+        for (int y = 0; y < DATA_CELLS; y++)
+            for (int x = 0; x < DATA_CELLS; x++)
+                d += (r.at<uchar> (y, x) != want.at<uchar> (y, x));
+        best = std::min (best, d);
+    }
+    return best;
+}
+
+/*
+ * Board->image fit from the nearest found tags.
+ *
+ * Local on purpose: this lens distorts enough that ONE global homography leaves a
+ * ~3.5 px median residual, far too coarse to predict a tag quad well enough to decode.
+ */
+bool local_homography (const AgGridSpec &spec, int tag_id,
+                       const std::map<int, std::vector<cv::Point2f> > &found,
+                       bool flip_x, bool flip_y, cv::Mat &H)
+{
+    std::vector<cv::Point2f> here;
+    ag_grid_board_corners (spec, tag_id, flip_x, flip_y, here);
+    const cv::Point2f c = centroid (here);
+
+    std::vector<std::pair<double, int> > bydist;
+    for (std::map<int, std::vector<cv::Point2f> >::const_iterator it = found.begin ();
+         it != found.end (); ++it) {
+        std::vector<cv::Point2f> bc;
+        ag_grid_board_corners (spec, it->first, flip_x, flip_y, bc);
+        bydist.push_back (std::make_pair (cv::norm (centroid (bc) - c), it->first));
+    }
+    std::sort (bydist.begin (), bydist.end ());
+    const size_t take = std::min (static_cast<size_t> (kNeighbours), bydist.size ());
+    if (take < 3)
+        return false;
+
+    std::vector<cv::Point2f> src, dst;
+    for (size_t i = 0; i < take; i++) {
+        std::vector<cv::Point2f> bc;
+        ag_grid_board_corners (spec, bydist[i].second, flip_x, flip_y, bc);
+        const std::vector<cv::Point2f> &im = found.find (bydist[i].second)->second;
+        src.insert (src.end (), bc.begin (), bc.end ());
+        dst.insert (dst.end (), im.begin (), im.end ());
+    }
+    H = cv::findHomography (src, dst, 0);
+    return !H.empty ();
+}
+
+/*
+ * Seed pass: candidate quads from plain imgproc, decoded with the same reader the
+ * guided pass uses.
+ *
+ * Deliberately NOT ArUco. ArUco would work, but it lives in opencv_contrib on the
+ * OpenCV that Ubuntu 22.04 packages, and pulling contrib in drags GDAL, GTK-3, x265 and
+ * GDCM -- 279 packages, +314 MB on a controller with a 5 GB rootfs -- to get one
+ * adaptive-threshold-and-decode that is a few dozen lines of imgproc. Dropping it keeps
+ * the whole detector on core+imgproc+calib3d, which the distro packages plainly.
+ *
+ * It also reads MORE, because the decoder is better matched to this board than either
+ * ArUco's or libapriltag's: measured over 20 eyes of sweep_am this seeds 21-46 tags per
+ * eye where ArUco managed 8-31 and libapriltag 0-11. The guided pass needs four.
+ */
+std::map<int, std::vector<cv::Point2f> > blind_detect (const cv::Mat &gray, int num_tags)
+{
+    std::map<int, std::vector<cv::Point2f> > found;
+    const std::vector<cv::Mat> &want = expected_bits_table ();
+
+    for (int w = 0; w < 4; w++) {
+        cv::Mat th;
+        cv::adaptiveThreshold (gray, th, 255, cv::ADAPTIVE_THRESH_MEAN_C,
+                               cv::THRESH_BINARY_INV, kThreshWindows[w][1] | 1,
+                               kThreshWindows[w][2]);
+        std::vector<std::vector<cv::Point> > contours;
+        cv::findContours (th, contours, cv::RETR_LIST, cv::CHAIN_APPROX_SIMPLE);
+
+        for (size_t i = 0; i < contours.size (); i++) {
+            const double per = cv::arcLength (contours[i], true);
+            if (per < kMinPerimeter)
+                continue;
+            std::vector<cv::Point> ap;
+            cv::approxPolyDP (contours[i], ap, 0.05 * per, true);
+            if (ap.size () != 4 || !cv::isContourConvex (ap) || cv::contourArea (ap) < kMinArea)
+                continue;
+
+            std::vector<cv::Point2f> quad;
+            for (int k = 0; k < 4; k++)
+                quad.push_back (cv::Point2f ((float) ap[k].x, (float) ap[k].y));
+            /* One handedness, so the remaining ambiguity is a cyclic shift only. */
+            if (cv::contourArea (quad, true) < 0)
+                std::reverse (quad.begin (), quad.end ());
+
+            /* Try each cyclic shift and keep the one that decodes DIRECTLY, so the
+             * accepted corners are already in board order -- the local homography the
+             * guided pass fits is only as good as the seed winding. */
+            for (int shift = 0; shift < 4; shift++) {
+                std::vector<cv::Point2f> q;
+                for (int k = 0; k < 4; k++)
+                    q.push_back (quad[(k + shift) % 4]);
+                cv::Mat bits;
+                if (read_cells (gray, q, bits) <= kMinContrast)
+                    break;                       /* contrast does not depend on shift */
+                bool hit = false;
+                for (int id = 0; id < num_tags && !hit; id++) {
+                    if (found.count (id))
+                        continue;
+                    int d = 0;
+                    for (int y = 0; y < DATA_CELLS; y++)
+                        for (int x = 0; x < DATA_CELLS; x++)
+                            d += (bits.at<uchar> (y, x) != want[id].at<uchar> (y, x));
+                    if (d <= kMaxHamming) {
+                        /* approxPolyDP corners are integer, and the guided pass fits
+                         * its local homography on these -- a whole-pixel seed corner
+                         * is enough to make a neighbour fail verification. */
+                        refine (gray, q);
+                        found[id] = q;
+                        hit = true;
+                    }
+                }
+                if (hit)
+                    break;
+            }
+        }
+    }
+    return found;
+}
+
+}  // namespace
+
+void
+ag_grid_board_corners (const AgGridSpec &spec, int tag_id, bool flip_x, bool flip_y,
+                       std::vector<cv::Point2f> &out)
+{
+    int row = tag_id / spec.columns;
+    int col = tag_id % spec.columns;
+    if (flip_x) col = spec.columns - 1 - col;
+    if (flip_y) row = spec.rows - 1 - row;
+    const float x0 = static_cast<float> (col * spec.pitch_mm ());
+    const float y0 = static_cast<float> (row * spec.pitch_mm ());
+    const float t = static_cast<float> (spec.tag_mm);
+    out.clear ();
+    out.push_back (cv::Point2f (x0, y0));
+    out.push_back (cv::Point2f (x0 + t, y0));
+    out.push_back (cv::Point2f (x0 + t, y0 + t));
+    out.push_back (cv::Point2f (x0, y0 + t));
+}
+
+double
+ag_grid_pick_orientation (const AgGridSpec &spec,
+                          const std::map<int, std::vector<cv::Point2f> > &found,
+                          bool *flip_x, bool *flip_y)
+{
+    double best = std::numeric_limits<double>::infinity ();
+    *flip_x = true; *flip_y = false;
+    for (int fx = 0; fx < 2; fx++) {
+        for (int fy = 0; fy < 2; fy++) {
+            std::vector<cv::Point2f> src, dst;
+            for (std::map<int, std::vector<cv::Point2f> >::const_iterator it = found.begin ();
+                 it != found.end (); ++it) {
+                std::vector<cv::Point2f> bc;
+                ag_grid_board_corners (spec, it->first, fx != 0, fy != 0, bc);
+                src.insert (src.end (), bc.begin (), bc.end ());
+                dst.insert (dst.end (), it->second.begin (), it->second.end ());
+            }
+            if (src.size () < 4)
+                continue;
+            cv::Mat H = cv::findHomography (src, dst, cv::RANSAC, 5.0);
+            if (H.empty ())
+                continue;
+            std::vector<cv::Point2f> proj;
+            cv::perspectiveTransform (src, proj, H);
+            std::vector<double> err (proj.size ());
+            for (size_t i = 0; i < proj.size (); i++)
+                err[i] = cv::norm (proj[i] - dst[i]);
+            std::nth_element (err.begin (), err.begin () + err.size () / 2, err.end ());
+            const double median = err[err.size () / 2];
+            if (median < best) { best = median; *flip_x = fx != 0; *flip_y = fy != 0; }
+        }
+    }
+    return best;
+}
+
+AgGridDetection
+ag_grid_detect (const cv::Mat &gray, const AgGridSpec &spec)
+{
+    AgGridDetection out;
+    out.spec = spec;
+    out.corners = blind_detect (gray, spec.num_tags ());
+    for (std::map<int, std::vector<cv::Point2f> >::const_iterator it = out.corners.begin ();
+         it != out.corners.end (); ++it)
+        out.blind_ids.insert (it->first);
+    if (out.corners.size () < 4)
+        return out;
+
+    ag_grid_pick_orientation (spec, out.corners, &out.flip_x, &out.flip_y);
+
+    /*
+     * Throw out seeds the rest of the board disagrees with.
+     *
+     * The seed pass reads each candidate quad in isolation, so a quad that landed on
+     * the wrong square can still decode -- and once an id is seeded the guided pass
+     * never revisits it, so one bad seed both squats on its id AND drags the local
+     * homography of every neighbour that uses it. Measured against the reference
+     * detector, the bad ones sit ~12 px out while the good ones agree to 0.0006 px, so
+     * they separate cleanly: fit each seed from its neighbours ONLY and drop the ones
+     * the fit cannot place. A dropped id is not lost -- the guided pass re-derives it
+     * from the survivors, which is exactly the machinery that recovers 20-40 tags a
+     * frame anyway.
+     */
+    {
+        std::map<int, std::vector<cv::Point2f> > seeds = out.corners;
+        for (std::map<int, std::vector<cv::Point2f> >::const_iterator it = seeds.begin ();
+             it != seeds.end (); ++it) {
+            std::map<int, std::vector<cv::Point2f> > others = seeds;
+            others.erase (it->first);
+            cv::Mat H;
+            if (!local_homography (spec, it->first, others, out.flip_x, out.flip_y, H))
+                continue;
+            std::vector<cv::Point2f> bc, pred;
+            ag_grid_board_corners (spec, it->first, out.flip_x, out.flip_y, bc);
+            cv::perspectiveTransform (bc, pred, H);
+            double worst = 0;
+            for (size_t k = 0; k < 4; k++)
+                worst = std::max (worst, cv::norm (pred[k] - it->second[k]));
+            if (worst > kSeedTolPx) {
+                out.corners.erase (it->first);
+                out.blind_ids.erase (it->first);
+            }
+        }
+    }
+    if (out.corners.size () < 4)
+        return out;
+
+    for (int pass = 0; pass < kGuidedPasses; pass++) {
+        bool progress = false;
+        for (int id = 0; id < spec.num_tags (); id++) {
+            if (out.corners.count (id))
+                continue;
+            cv::Mat H;
+            if (!local_homography (spec, id, out.corners, out.flip_x, out.flip_y, H))
+                continue;
+            std::vector<cv::Point2f> bc, quad;
+            ag_grid_board_corners (spec, id, out.flip_x, out.flip_y, bc);
+            cv::perspectiveTransform (bc, quad, H);
+
+            bool inside = true;
+            for (size_t i = 0; i < quad.size (); i++)
+                if (quad[i].x <= 1 || quad[i].x >= gray.cols - 2 ||
+                    quad[i].y <= 1 || quad[i].y >= gray.rows - 2)
+                    inside = false;
+            if (!inside)
+                continue;                       /* predicted outside the frame */
+
+            refine (gray, quad);
+            cv::Mat bits;
+            const double contrast = read_cells (gray, quad, bits);
+            if (contrast <= kMinContrast || hamming (bits, expected_bits (id)) > kMaxHamming)
+                continue;
+            out.corners[id] = quad;
+            out.guided_ids.insert (id);
+            progress = true;
+        }
+        if (!progress)
+            break;
+    }
+
+    /* One refinement convention for every tag. The plain sweep keeps whichever
+     * threshold window read the most tags, and that choice moves frame to frame -- so
+     * without this a tag read blind in one frame and predicted in the next comes back
+     * with corners from two different estimators. Measured over 6 frames of a static
+     * scene, unifying the pass cuts the p90 corner spread by roughly half. */
+    for (std::map<int, std::vector<cv::Point2f> >::iterator it = out.corners.begin ();
+         it != out.corners.end (); ++it)
+        refine (gray, it->second);
+
+    return out;
+}
+
+#endif /* HAVE_OPENCV */

--- a/src/aprilgrid.cpp
+++ b/src/aprilgrid.cpp
@@ -1,6 +1,6 @@
 /* aprilgrid.cpp — see aprilgrid.hpp. */
 
-#ifdef HAVE_OPENCV
+#ifdef HAVE_OPENCV_CALIB
 
 #include "aprilgrid.hpp"
 
@@ -428,4 +428,4 @@ ag_grid_detect (const cv::Mat &gray, const AgGridSpec &spec)
     return out;
 }
 
-#endif /* HAVE_OPENCV */
+#endif /* HAVE_OPENCV_CALIB */

--- a/src/aprilgrid.hpp
+++ b/src/aprilgrid.hpp
@@ -1,0 +1,83 @@
+/*
+ * aprilgrid.hpp — whole-board detection for calib.io / Kalibr AprilGrid targets.
+ *
+ * The border-2 family in apriltag_detect.c makes a SINGLE tag decodable. This is the
+ * other half: it knows the BOARD, so a tag the plain pass missed can be predicted from
+ * its neighbours and verified rather than lost. On the bench that is the difference
+ * between a handful of tags and all 70 -- and the calibration solve wants all 70,
+ * because the ones a plain pass drops are the oblique, dim, frame-edge tags that carry
+ * most of the distortion signal.
+ *
+ * Needs only OpenCV core+imgproc+calib3d (guarded by HAVE_OPENCV), plus libapriltag's
+ * tag36h11 code table -- which is already vendored, and which the b2 family leaves
+ * untouched (verified: 0 of 587 codes differ, so stock and b2 are the same table).
+ * Deliberately no ArUco: it would do the seed pass, but on the OpenCV that Ubuntu
+ * 22.04 packages ArUco lives in opencv_contrib, and pulling contrib in drags GDAL,
+ * GTK-3, x265 and GDCM -- 279 packages, +314 MB on a box with a 5 GB rootfs -- for one
+ * adaptive-threshold-and-decode. Without it the three modules we do need are stock apt
+ * packages: +18 MB, no source build, no version pin.
+ *
+ * libapriltag's DETECTOR is also not used here, and that is not an oversight: it finds
+ * the quads and then decodes almost none of them at the ~3.5 px/cell this board lands
+ * at -- 27-34 quads a frame for 0-11 decodes, exactly zero on 7 of 11 frames, including
+ * clean fronto-parallel ones. quad_sigma, decode_sharpening, min_white_black_diff,
+ * min_cluster_pixels and 2x upsampling each made it worse. The reader in this file
+ * manages 21-49 seeds a frame on the same images. The guided pass needs four, so the
+ * seed pass is where the whole thing lives or dies.
+ */
+
+#ifndef AG_APRILGRID_HPP
+#define AG_APRILGRID_HPP
+
+#ifdef HAVE_OPENCV
+
+#include <map>
+#include <set>
+#include <vector>
+#include <opencv2/core.hpp>
+
+/* Physical geometry of the target. Millimetres. Defaults match the calib.io board on
+ * the bench: 7x10, 25 mm tags, 7.5 mm gaps, tag36h11 in the two-cell-border
+ * convention. */
+struct AgGridSpec {
+    int    columns = 10;
+    int    rows    = 7;
+    double tag_mm  = 25.0;
+    double gap_mm  = 7.5;
+
+    double pitch_mm () const { return tag_mm + gap_mm; }
+    int    num_tags () const { return rows * columns; }
+};
+
+struct AgGridDetection {
+    /* tag id -> 4 corners, ArUco order, pixels. */
+    std::map<int, std::vector<cv::Point2f> > corners;
+    std::set<int> blind_ids;      /* read by the plain pass */
+    std::set<int> guided_ids;     /* recovered by prediction + verification */
+    bool flip_x = true;
+    bool flip_y = false;
+    AgGridSpec spec;
+};
+
+/*
+ * The tag's four black-square corners in board millimetres, ArUco order.
+ *
+ * flip_x/flip_y express how the board is mounted relative to the camera. Do not
+ * assume them -- ag_grid_pick_orientation() chooses by homography residual.
+ */
+void ag_grid_board_corners (const AgGridSpec &spec, int tag_id,
+                            bool flip_x, bool flip_y,
+                            std::vector<cv::Point2f> &out);
+
+/* Which way the ids run on this board, by lowest global homography residual.
+ * Returns that residual in pixels; sets flip_x/flip_y. */
+double ag_grid_pick_orientation (const AgGridSpec &spec,
+                                 const std::map<int, std::vector<cv::Point2f> > &found,
+                                 bool *flip_x, bool *flip_y);
+
+/* Plain ArUco pass with the two-cell border model, then neighbour-guided prediction
+ * with per-tag verification. `gray` is 8-bit single channel. */
+AgGridDetection ag_grid_detect (const cv::Mat &gray, const AgGridSpec &spec);
+
+#endif /* HAVE_OPENCV */
+#endif /* AG_APRILGRID_HPP */

--- a/src/aprilgrid.hpp
+++ b/src/aprilgrid.hpp
@@ -8,7 +8,7 @@
  * because the ones a plain pass drops are the oblique, dim, frame-edge tags that carry
  * most of the distortion signal.
  *
- * Needs only OpenCV core+imgproc+calib3d (guarded by HAVE_OPENCV), plus libapriltag's
+ * Needs only OpenCV core+imgproc+calib3d (guarded by HAVE_OPENCV_CALIB), plus libapriltag's
  * tag36h11 code table -- which is already vendored, and which the b2 family leaves
  * untouched (verified: 0 of 587 codes differ, so stock and b2 are the same table).
  * Deliberately no ArUco: it would do the seed pass, but on the OpenCV that Ubuntu
@@ -29,7 +29,7 @@
 #ifndef AG_APRILGRID_HPP
 #define AG_APRILGRID_HPP
 
-#ifdef HAVE_OPENCV
+#ifdef HAVE_OPENCV_CALIB
 
 #include <map>
 #include <set>
@@ -79,5 +79,5 @@ double ag_grid_pick_orientation (const AgGridSpec &spec,
  * with per-tag verification. `gray` is 8-bit single channel. */
 AgGridDetection ag_grid_detect (const cv::Mat &gray, const AgGridSpec &spec);
 
-#endif /* HAVE_OPENCV */
+#endif /* HAVE_OPENCV_CALIB */
 #endif /* AG_APRILGRID_HPP */

--- a/src/apriltag_detect.c
+++ b/src/apriltag_detect.c
@@ -12,24 +12,202 @@
 #include "common.h"
 
 #include <apriltag_pose.h>
-#include <tagStandard52h13.h>
+#include <tag16h5.h>
+#include <tag25h9.h>
+#include <tag36h10.h>
+#include <tag36h11.h>
+#include <tagCircle21h7.h>
+#include <tagCircle49h12.h>
+#include <tagCustom48h12.h>
 #include <tagStandard41h12.h>
+#include <tagStandard52h13.h>
 #include <common/image_u8.h>
 
 #include <math.h>
+#include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/*  Family table — every family apriltag 3 ships                        */
+/* ------------------------------------------------------------------ */
+
+typedef apriltag_family_t *(*AgFamilyCreate) (void);
+typedef void (*AgFamilyDestroy) (apriltag_family_t *);
+
+typedef struct {
+    const char      *name;
+    AgFamilyCreate   create;
+    AgFamilyDestroy  destroy;
+    int              ncodes;   /* for the cost warning only */
+} AgFamilyDef;
+
+/*
+ * tag36h11 with a TWO-CELL black border, as calib.io and Kalibr render AprilGrid
+ * calibration targets.
+ *
+ * apriltag3's stock tag36h11 hard-codes a one-cell border (width_at_border 8,
+ * total_width 10), so on a two-cell board its bit sample points land on the border
+ * ring instead of the data and every quad fails to decode -- not poorly, but zero
+ * tags at any distance, exposure or image quality. Widening the frame by one cell on
+ * each side and shifting every bit coordinate to match moves the samples back onto
+ * the payload. Same 587 codes, same hamming distances; only the geometry differs.
+ *
+ * Measured on a UR5e bench cell, PDH016S at binning 1, calib.io 7x10 / 25 mm board:
+ * stock tag36h11 reads 0 of 70 tags, this family reads 57-69 depending on exposure,
+ * and beats OpenCV ArUco with markerBorderBits=2 on every frame tested.
+ *
+ * tag36h11_destroy is the correct destructor: it frees name, bit_x, bit_y and the
+ * struct, all of which this still owns.
+ */
+static apriltag_family_t *
+tag36h11b2_create (void)
+{
+    apriltag_family_t *tf = tag36h11_create ();
+
+    tf->width_at_border += 2;
+    tf->total_width     += 2;
+    for (uint32_t i = 0; i < tf->nbits; i++) {
+        tf->bit_x[i] += 1;
+        tf->bit_y[i] += 1;
+    }
+
+    free (tf->name);
+    tf->name = strdup ("tag36h11b2");
+    return tf;
+}
+
+static const AgFamilyDef ag_families[AG_TAG_FAMILY_MAX] = {
+    { "tag16h5",          tag16h5_create,          tag16h5_destroy,             30 },
+    { "tag25h9",          tag25h9_create,          tag25h9_destroy,             35 },
+    { "tag36h10",         tag36h10_create,         tag36h10_destroy,          2320 },
+    { "tag36h11",         tag36h11_create,         tag36h11_destroy,           587 },
+    { "tag36h11b2",       tag36h11b2_create,       tag36h11_destroy,           587 },
+    { "tagCircle21h7",    tagCircle21h7_create,    tagCircle21h7_destroy,       38 },
+    { "tagCircle49h12",   tagCircle49h12_create,   tagCircle49h12_destroy,   65535 },
+    { "tagCustom48h12",   tagCustom48h12_create,   tagCustom48h12_destroy,   42211 },
+    { "tagStandard41h12", tagStandard41h12_create, tagStandard41h12_destroy,  2115 },
+    { "tagStandard52h13", tagStandard52h13_create, tagStandard52h13_destroy, 48714 },
+};
+
+/* Registered when nobody says otherwise — the historical pair, so an empty
+ * registry behaves exactly as it always did. */
+static const char ag_default_families[] = "tagStandard52h13,tagStandard41h12";
+
+/* Big enough that registering it needlessly is a real per-frame cost. */
+#define AG_FAMILY_EXPENSIVE_NCODES  10000
+
+const char *const *
+ag_apriltag_family_names (int *n_out)
+{
+    static const char *names[AG_TAG_FAMILY_MAX];
+    static gboolean init = FALSE;
+    if (!init) {
+        for (int i = 0; i < AG_TAG_FAMILY_MAX; i++)
+            names[i] = ag_families[i].name;
+        init = TRUE;
+    }
+    if (n_out)
+        *n_out = AG_TAG_FAMILY_MAX;
+    return names;
+}
+
+int
+ag_apriltag_family_index (const char *token)
+{
+    if (!token || !*token)
+        return -1;
+
+    for (int i = 0; i < AG_TAG_FAMILY_MAX; i++)
+        if (g_ascii_strcasecmp (token, ag_families[i].name) == 0)
+            return i;
+
+    /* Legacy bare suffixes ("41h12", "52h13"). Only an UNAMBIGUOUS suffix
+     * match counts, so a family added later can never silently steal a token
+     * that used to mean something else. */
+    int hit = -1;
+    for (int i = 0; i < AG_TAG_FAMILY_MAX; i++) {
+        size_t nl = strlen (ag_families[i].name), tl = strlen (token);
+        if (tl < nl && g_ascii_strcasecmp (ag_families[i].name + (nl - tl), token) == 0) {
+            if (hit >= 0)
+                return -1;
+            hit = i;
+        }
+    }
+    return hit;
+}
+
+char *
+ag_apriltag_family_summary (const AgApriltagContext *ctx)
+{
+    GString *s = g_string_new (NULL);
+    if (ctx) {
+        for (int i = 0; i < AG_TAG_FAMILY_MAX; i++)
+            if (ctx->families[i])
+                g_string_append_printf (s, "%s%s", s->len ? "," : "", ag_families[i].name);
+    }
+    if (!s->len)
+        g_string_append (s, "(none)");
+    return g_string_free (s, FALSE);
+}
 
 AgApriltagContext *
 ag_apriltag_create (void)
 {
+    return ag_apriltag_create_families (NULL);
+}
+
+AgApriltagContext *
+ag_apriltag_create_families (const char *csv)
+{
     AgApriltagContext *ctx = g_malloc0 (sizeof *ctx);
+    gboolean want[AG_TAG_FAMILY_MAX] = { FALSE };
+    int n_want = 0;
 
-    ctx->family_52h13 = tagStandard52h13_create ();
-    ctx->family_41h12 = tagStandard41h12_create ();
-    ctx->detector     = apriltag_detector_create ();
+    if (csv && *csv) {
+        char **toks = g_strsplit (csv, ",", -1);
+        for (int i = 0; toks[i]; i++) {
+            char *tok = g_strstrip (toks[i]);
+            if (!*tok)
+                continue;
+            int idx = ag_apriltag_family_index (tok);
+            if (idx < 0) {
+                fprintf (stderr, "apriltag: unknown family '%s' — ignored\n", tok);
+                continue;
+            }
+            if (!want[idx]) {
+                want[idx] = TRUE;
+                n_want++;
+            }
+        }
+        g_strfreev (toks);
+    }
 
-    apriltag_detector_add_family (ctx->detector, ctx->family_52h13);
-    apriltag_detector_add_family (ctx->detector, ctx->family_41h12);
+    if (n_want == 0) {
+        /* Nothing asked for, or nothing recognised: fall back to the default
+         * pair rather than leaving the detector blind. */
+        if (csv && *csv)
+            fprintf (stderr, "apriltag: no usable family in '%s' — using defaults\n", csv);
+        char **toks = g_strsplit (ag_default_families, ",", -1);
+        for (int i = 0; toks[i]; i++) {
+            int idx = ag_apriltag_family_index (toks[i]);
+            if (idx >= 0)
+                want[idx] = TRUE;
+        }
+        g_strfreev (toks);
+    }
+
+    ctx->detector = apriltag_detector_create ();
+    for (int i = 0; i < AG_TAG_FAMILY_MAX; i++) {
+        if (!want[i])
+            continue;
+        ctx->families[i] = ag_families[i].create ();
+        apriltag_detector_add_family (ctx->detector, ctx->families[i]);
+        if (ag_families[i].ncodes >= AG_FAMILY_EXPENSIVE_NCODES)
+            fprintf (stderr, "apriltag: %s registered (%d codes — decoded against on"
+                             " every quad)\n",
+                     ag_families[i].name, ag_families[i].ncodes);
+    }
 
     ctx->detector->quad_decimate    = 1.5f;
     ctx->detector->quad_sigma       = 0.0f;
@@ -47,11 +225,20 @@ ag_apriltag_destroy (AgApriltagContext *ctx)
         return;
     if (ctx->detector)
         apriltag_detector_destroy (ctx->detector);
-    if (ctx->family_52h13)
-        tagStandard52h13_destroy (ctx->family_52h13);
-    if (ctx->family_41h12)
-        tagStandard41h12_destroy (ctx->family_41h12);
+    for (int i = 0; i < AG_TAG_FAMILY_MAX; i++)
+        if (ctx->families[i])
+            ag_families[i].destroy (ctx->families[i]);
     g_free (ctx);
+}
+
+/*
+ * Family name for a detection. det->family is owned by the context, which
+ * outlives every overlay built from it, so the overlay borrows the pointer.
+ */
+static const char *
+overlay_family (const apriltag_detection_t *det)
+{
+    return (det && det->family && det->family->name) ? det->family->name : "?";
 }
 
 void
@@ -64,6 +251,60 @@ ag_apriltag_estimate_intrinsics (guint proc_sub_w, guint proc_h,
     *fy = *fx;
     *cx = (double) proc_sub_w / 2.0;
     *cy = (double) proc_h / 2.0;
+}
+
+zarray_t *
+ag_detect_tags (apriltag_detector_t *detector,
+                const guint8 *gray, guint width, guint height)
+{
+    image_u8_t im = {
+        .width  = (int32_t) width,
+        .height = (int32_t) height,
+        .stride = (int32_t) width,
+        .buf    = (uint8_t *) gray
+    };
+    return apriltag_detector_detect (detector, &im);
+}
+
+int
+ag_pose_from_detections (zarray_t *detections,
+                         double tag_size_m,
+                         double fx, double fy, double cx, double cy,
+                         AgTagOverlay *overlays, int max_overlays)
+{
+    int n_overlays = 0;
+
+    for (int i = 0; i < zarray_size (detections) && n_overlays < max_overlays; i++) {
+        apriltag_detection_t *det;
+        zarray_get (detections, i, &det);
+
+        apriltag_detection_info_t info = {
+            .det = det, .tagsize = tag_size_m,
+            .fx = fx, .fy = fy, .cx = cx, .cy = cy
+        };
+        apriltag_pose_t pose;
+        estimate_tag_pose (&info, &pose);
+
+        for (int p = 0; p < 4; p++) {
+            overlays[n_overlays].p[p][0] = det->p[p][0];
+            overlays[n_overlays].p[p][1] = det->p[p][1];
+        }
+        overlays[n_overlays].id        = det->id;
+        overlays[n_overlays].family    = overlay_family (det);
+        overlays[n_overlays].center[0] = det->c[0];
+        overlays[n_overlays].center[1] = det->c[1];
+        overlays[n_overlays].t[0]      = matd_get (pose.t, 0, 0);
+        overlays[n_overlays].t[1]      = matd_get (pose.t, 1, 0);
+        overlays[n_overlays].t[2]      = matd_get (pose.t, 2, 0);
+        for (int r = 0; r < 3; r++)
+            for (int cc = 0; cc < 3; cc++)
+                overlays[n_overlays].R[r * 3 + cc] = matd_get (pose.R, r, cc);
+        n_overlays++;
+
+        matd_destroy (pose.R);
+        matd_destroy (pose.t);
+    }
+    return n_overlays;
 }
 
 int
@@ -104,12 +345,12 @@ ag_detect_tags_and_pose (apriltag_detector_t *detector,
 
         if (!quiet) {
             printf ("apriltag frame=%" G_GUINT64_FORMAT
-                    " eye=%s id=%d hamming=%d margin=%.1f"
+                    " eye=%s family=%s id=%d hamming=%d margin=%.1f"
                     " center=(%.1f,%.1f)"
                     " err=%.2e"
                     " R=[%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f]"
                     " t=[%.4f,%.4f,%.4f]\n",
-                    frame_num, eye_label,
+                    frame_num, eye_label, overlay_family (det),
                     det->id, det->hamming, det->decision_margin,
                     det->c[0], det->c[1],
                     pose_err,
@@ -129,11 +370,15 @@ ag_detect_tags_and_pose (apriltag_detector_t *detector,
                 overlays[n_overlays].p[c][1] = det->p[c][1];
             }
             overlays[n_overlays].id        = det->id;
+            overlays[n_overlays].family    = overlay_family (det);
             overlays[n_overlays].center[0] = det->c[0];
             overlays[n_overlays].center[1] = det->c[1];
             overlays[n_overlays].t[0]      = matd_get (pose.t, 0, 0);
             overlays[n_overlays].t[1]      = matd_get (pose.t, 1, 0);
             overlays[n_overlays].t[2]      = matd_get (pose.t, 2, 0);
+            for (int r = 0; r < 3; r++)
+                for (int c = 0; c < 3; c++)
+                    overlays[n_overlays].R[r * 3 + c] = matd_get (pose.R, r, c);
             n_overlays++;
         }
 
@@ -173,10 +418,12 @@ ag_tag_tracker_update (AgTagTracker *tracker,
     for (int i = 0; i < n_overlays; i++) {
         const AgTagOverlay *ov = &overlays[i];
 
-        /* Search for existing tracked tag with this ID. */
+        /* Search by (family, id) — an id is unique only within its family, so
+         * keying on the id alone merges two different physical tags. */
         AgTrackedTag *found = NULL;
         for (int j = 0; j < tracker->n_tags; j++) {
-            if (tracker->tags[j].id == ov->id) {
+            if (tracker->tags[j].id == ov->id &&
+                g_strcmp0 (tracker->tags[j].family, ov->family) == 0) {
                 found = &tracker->tags[j];
                 break;
             }
@@ -187,6 +434,7 @@ ag_tag_tracker_update (AgTagTracker *tracker,
             if (tracker->n_tags < AG_MAX_TRACKED_TAGS) {
                 found = &tracker->tags[tracker->n_tags++];
                 found->id = ov->id;
+                found->family = ov->family;
                 found->active = FALSE;  /* will be set below */
             } else {
                 continue;  /* tracker full */
@@ -195,10 +443,10 @@ ag_tag_tracker_update (AgTagTracker *tracker,
 
         if (!found->active) {
             /* Appeared (first time or reappeared after disappearance). */
-            printf ("apriltag_event eye=%s id=%d event=appeared"
+            printf ("apriltag_event eye=%s family=%s id=%d event=appeared"
                     " frame=%" G_GUINT64_FORMAT
                     " center=(%.1f,%.1f) t=[%.4f,%.4f,%.4f]\n",
-                    tracker->eye_label, ov->id, frame_num,
+                    tracker->eye_label, ov->family, ov->id, frame_num,
                     ov->center[0], ov->center[1],
                     ov->t[0], ov->t[1], ov->t[2]);
             found->active = TRUE;
@@ -215,10 +463,10 @@ ag_tag_tracker_update (AgTagTracker *tracker,
 
             if (dist_px > tracker->move_threshold_px ||
                 dist_m  > tracker->move_threshold_m) {
-                printf ("apriltag_event eye=%s id=%d event=moved"
+                printf ("apriltag_event eye=%s family=%s id=%d event=moved"
                         " frame=%" G_GUINT64_FORMAT
                         " center=(%.1f,%.1f) t=[%.4f,%.4f,%.4f]\n",
-                        tracker->eye_label, ov->id, frame_num,
+                        tracker->eye_label, ov->family, ov->id, frame_num,
                         ov->center[0], ov->center[1],
                         ov->t[0], ov->t[1], ov->t[2]);
             }
@@ -241,10 +489,10 @@ ag_tag_tracker_check_disappeared (AgTagTracker *tracker,
         AgTrackedTag *tag = &tracker->tags[i];
         if (tag->active &&
             frame_num - tag->frame_last_seen > (guint64) tracker->disappear_frames) {
-            printf ("apriltag_event eye=%s id=%d event=disappeared"
+            printf ("apriltag_event eye=%s family=%s id=%d event=disappeared"
                     " frame=%" G_GUINT64_FORMAT
                     " last_center=(%.1f,%.1f)\n",
-                    tracker->eye_label, tag->id, frame_num,
+                    tracker->eye_label, tag->family, tag->id, frame_num,
                     tag->center_x, tag->center_y);
             tag->active = FALSE;
         }

--- a/src/apriltag_detect.h
+++ b/src/apriltag_detect.h
@@ -21,34 +21,74 @@
 #define AG_PIXEL_PITCH_UM  3.45
 #define AG_LENS_FL_UM      3000.0  /* 3 mm */
 
+/*
+ * Every tag family the apriltag 3 library ships. Index-aligned with the name
+ * table from ag_apriltag_family_names() and with AgApriltagContext.families[].
+ */
+#define AG_TAG_FAMILY_MAX  10
+
+/*
+ * Canonical family names ("tag36h11", "tagStandard41h12", …) in table order.
+ * *n_out receives AG_TAG_FAMILY_MAX. The strings are static.
+ */
+const char *const *ag_apriltag_family_names (int *n_out);
+
+/*
+ * Resolve one family name to its table index, or -1. Accepts the canonical
+ * name case-insensitively, and the bare suffix ("41h12" -> tagStandard41h12)
+ * that older --families arguments used.
+ */
+int ag_apriltag_family_index (const char *token);
+
 /* Corners and metadata for one detected tag (pixel coords within a single eye). */
 typedef struct {
     double p[4][2];   /* corner points, counter-clockwise */
-    int    id;        /* tag family ID */
+    int    id;        /* tag ID — unique only WITHIN a family */
+    const char *family;  /* canonical family name; static, never NULL */
     double center[2]; /* center pixel coordinates */
-    double t[3];      /* translation vector from pose estimate */
+    double t[3];      /* translation vector from pose estimate (tag origin in camera frame) */
+    double R[9];      /* row-major rotation (tag -> camera) from pose estimate */
 } AgTagOverlay;
 
 #define AG_MAX_TAG_OVERLAYS  32
 
 /*
- * Bundled AprilTag detector context — owns the detector and all
- * registered tag families.
+ * Bundled AprilTag detector context — owns the detector and every registered
+ * family. families[i] is non-NULL exactly when the family at table index i is
+ * registered.
  */
 typedef struct {
     apriltag_detector_t *detector;
-    apriltag_family_t   *family_52h13;
-    apriltag_family_t   *family_41h12;
+    apriltag_family_t   *families[AG_TAG_FAMILY_MAX];
 } AgApriltagContext;
 
 /*
- * Create an AprilTag detector with tagStandard52h13 and tagStandard41h12
- * families (quad_decimate=1.5, nthreads=1, refine_edges=1,
- * decode_sharpening=0.25).
+ * Create an AprilTag detector with the default family set (tagStandard52h13 +
+ * tagStandard41h12), quad_decimate=1.5, nthreads=1, refine_edges=1,
+ * decode_sharpening=0.25.
  *
  * Returns the context, or NULL on failure.
  */
 AgApriltagContext *ag_apriltag_create (void);
+
+/*
+ * Same, but registering only the families named in a comma-separated list.
+ *
+ * Register only what is in use: every registered family is decoded against on
+ * EVERY quad, and the big tables cost both to build and to search —
+ * tagStandard52h13 is ~48k codes, tagCircle49h12 ~65k, tagCustom48h12 ~42k.
+ *
+ * Unknown tokens are reported on stderr and skipped. An empty or entirely
+ * unrecognised list falls back to the default set — never leave a detector
+ * blind.
+ */
+AgApriltagContext *ag_apriltag_create_families (const char *csv);
+
+/*
+ * Comma-separated canonical names of the families a context registered, for
+ * logging. Caller frees with g_free().
+ */
+char *ag_apriltag_family_summary (const AgApriltagContext *ctx);
 
 /*
  * Destroy a context returned by ag_apriltag_create().  May be NULL.
@@ -74,6 +114,26 @@ void ag_apriltag_estimate_intrinsics (guint proc_sub_w, guint proc_h,
  *
  * Returns the number of tags detected (and stored in overlays[]).
  */
+/*
+ * Detection ONLY — the expensive half (quad extraction + decode). The returned
+ * zarray is owned by the caller and must be freed with
+ * apriltag_detections_destroy(). Pose is deliberately not computed here: pose
+ * depends on the tag SIZE, detection does not, so one detection can serve any
+ * number of differently-sized pose queries (see ag_pose_from_detections).
+ */
+zarray_t *ag_detect_tags (apriltag_detector_t *detector,
+                          const guint8 *gray,
+                          guint width, guint height);
+
+/*
+ * Pose for previously-detected tags — the cheap half (a 4-point solve each).
+ * Fills overlays[] and returns how many were written.
+ */
+int ag_pose_from_detections (zarray_t *detections,
+                             double tag_size_m,
+                             double fx, double fy, double cx, double cy,
+                             AgTagOverlay *overlays, int max_overlays);
+
 int ag_detect_tags_and_pose (apriltag_detector_t *detector,
                              const guint8 *gray,
                              guint width, guint height,
@@ -90,7 +150,8 @@ int ag_detect_tags_and_pose (apriltag_detector_t *detector,
 #define AG_MAX_TRACKED_TAGS  64
 
 typedef struct {
-    int      id;               /* tag family ID */
+    int      id;               /* tag ID — unique only WITHIN a family */
+    const char *family;        /* canonical family name; identity is (family, id) */
     double   center_x;         /* last-seen center X (pixels) */
     double   center_y;         /* last-seen center Y (pixels) */
     double   tx, ty, tz;       /* last-seen translation vector */

--- a/src/calib_solve.cpp
+++ b/src/calib_solve.cpp
@@ -1,6 +1,6 @@
 /* calib_solve.cpp — see calib_solve.hpp. */
 
-#ifdef HAVE_OPENCV
+#ifdef HAVE_OPENCV_CALIB
 
 #include "calib_solve.hpp"
 
@@ -629,4 +629,4 @@ ag_calib_solve (const std::string &session_dir, const std::string &out_dir_in,
     return 0;
 }
 
-#endif /* HAVE_OPENCV */
+#endif /* HAVE_OPENCV_CALIB */

--- a/src/calib_solve.cpp
+++ b/src/calib_solve.cpp
@@ -1,0 +1,632 @@
+/* calib_solve.cpp — see calib_solve.hpp. */
+
+#ifdef HAVE_OPENCV
+
+#include "calib_solve.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <sys/stat.h>
+#include <ctime>
+#include <vector>
+
+#include <opencv2/calib3d.hpp>
+#include <opencv2/imgproc.hpp>
+
+extern "C" {
+#include "npy.h"
+#include "../vendor/cJSON.h"
+}
+
+namespace {
+
+/*
+ * The distortion model must be IDENTICAL in the per-eye fit and the stereo fit.
+ * stereoCalibrate without this flag reads only the first 5 coefficients of an 8+
+ * coefficient vector and silently ignores k4..k6 -- the stereo fit then optimises
+ * against a different lens model than the intrinsics were fitted under. Measured on a
+ * real session: 44.0 px RMS and a 267 mm baseline, versus 0.27 px and 40 mm with the
+ * flag. It fails as a plausible-looking number, not as an error.
+ */
+const int DIST_MODEL_FLAG = cv::CALIB_RATIONAL_MODEL;
+
+const char *const ARCHIVE_FILES[8] = {
+    "cam_mats_left", "cam_mats_right", "dist_coefs_left", "dist_coefs_right",
+    "rect_trans_left", "rect_trans_right", "proj_mats_left", "proj_mats_right"};
+
+struct View {
+    int index;
+    cv::Matx44d base_T_flange;
+    /* tags seen by BOTH eyes -- the stereo pair */
+    std::vector<cv::Point3f> obj;
+    std::vector<cv::Point2f> left, right;
+    /* per-eye sets for the intrinsics fit (every tag that eye saw) */
+    std::vector<cv::Point3f> obj_l, obj_r;
+    std::vector<cv::Point2f> img_l, img_r;
+};
+
+cv::Matx44d rt (const cv::Vec3d &rvec, const cv::Vec3d &tvec)
+{
+    cv::Matx33d R;
+    cv::Rodrigues (rvec, R);
+    cv::Matx44d T = cv::Matx44d::eye ();
+    for (int r = 0; r < 3; r++) {
+        for (int c = 0; c < 3; c++) T(r, c) = R(r, c);
+        T(r, 3) = tvec[r];
+    }
+    return T;
+}
+
+cv::Vec3d translation_of (const cv::Matx44d &T) { return cv::Vec3d (T(0,3), T(1,3), T(2,3)); }
+
+/*
+ * Demosaic one eye out of an `ag-cam-tools serve` /latest.raw buffer.
+ *
+ * The buffer is PLANAR -- the whole left image, then the whole right -- and despite the
+ * gray8 header it is a Bayer RGGB mosaic. COLOR_BayerBG2GRAY is the phasing that
+ * matches this sensor.
+ */
+bool load_raw_frame (const std::string &path, int eye, int w, int h, cv::Mat &gray)
+{
+    std::ifstream f (path.c_str (), std::ios::binary);
+    if (!f)
+        return false;
+    std::vector<unsigned char> buf ((std::istreambuf_iterator<char> (f)),
+                                     std::istreambuf_iterator<char> ());
+    const size_t want = (size_t) 2 * w * h;
+    if (buf.size () != want) {
+        fprintf (stderr, "%s: expected %zu bytes for 2x%dx%d, got %zu\n",
+                 path.c_str (), want, w, h, buf.size ());
+        return false;
+    }
+    cv::Mat bayer (h, w, CV_8UC1, buf.data () + (size_t) eye * w * h);
+    cv::cvtColor (bayer, gray, cv::COLOR_BayerBG2GRAY);
+    return true;
+}
+
+/* Board corners for `ids`, in metres with z=0, paired with their image corners. */
+void pack (const AgGridDetection &d, const std::vector<int> &ids,
+           std::vector<cv::Point3f> &obj, std::vector<cv::Point2f> &img)
+{
+    obj.clear (); img.clear ();
+    for (size_t i = 0; i < ids.size (); i++) {
+        std::vector<cv::Point2f> bc;
+        ag_grid_board_corners (d.spec, ids[i], d.flip_x, d.flip_y, bc);
+        const std::vector<cv::Point2f> &im = d.corners.find (ids[i])->second;
+        for (int k = 0; k < 4; k++) {
+            obj.push_back (cv::Point3f (bc[k].x / 1000.f, bc[k].y / 1000.f, 0.f));
+            img.push_back (im[k]);
+        }
+    }
+}
+
+bool parse_capture_line (const std::string &line, int *index, cv::Matx44d *pose)
+{
+    cJSON *root = cJSON_Parse (line.c_str ());
+    if (!root)
+        return false;
+    bool ok = false;
+    cJSON *idx = cJSON_GetObjectItem (root, "index");
+    cJSON *btf = cJSON_GetObjectItem (root, "base_T_flange");
+    if (cJSON_IsNumber (idx) && cJSON_IsArray (btf) && cJSON_GetArraySize (btf) == 6) {
+        double v[6];
+        for (int i = 0; i < 6; i++)
+            v[i] = cJSON_GetArrayItem (btf, i)->valuedouble;
+        *index = idx->valueint;
+        /* [x y z rx ry rz] -- translation first, axis-angle second. */
+        *pose = rt (cv::Vec3d (v[3], v[4], v[5]), cv::Vec3d (v[0], v[1], v[2]));
+        ok = true;
+    }
+    cJSON_Delete (root);
+    return ok;
+}
+
+/* Detect both eyes of every capture and pair the tags up by id. */
+std::vector<View> load_views (const std::string &session, const AgCalibSolveOpts &o)
+{
+    std::vector<View> views;
+    std::ifstream jl ((session + "/capture.jsonl").c_str ());
+    if (!jl) {
+        fprintf (stderr, "%s/capture.jsonl not found\n", session.c_str ());
+        return views;
+    }
+    std::string line;
+    while (std::getline (jl, line)) {
+        if (line.empty ())
+            continue;
+        int index = -1;
+        cv::Matx44d pose;
+        if (!parse_capture_line (line, &index, &pose))
+            continue;
+
+        char name[512];
+        snprintf (name, sizeof name, "%s/view_%03d.raw", session.c_str (), index);
+        cv::Mat gray_l, gray_r;
+        if (!load_raw_frame (name, 0, o.eye_w, o.eye_h, gray_l) ||
+            !load_raw_frame (name, 1, o.eye_w, o.eye_h, gray_r)) {
+            if (o.verbose) printf ("  view %d: frame missing, skipped\n", index);
+            continue;
+        }
+        AgGridDetection dl = ag_grid_detect (gray_l, o.spec);
+        AgGridDetection dr = ag_grid_detect (gray_r, o.spec);
+
+        std::vector<int> shared, ids_l, ids_r;
+        for (std::map<int, std::vector<cv::Point2f> >::const_iterator it = dl.corners.begin ();
+             it != dl.corners.end (); ++it) {
+            ids_l.push_back (it->first);
+            if (dr.corners.count (it->first))
+                shared.push_back (it->first);
+        }
+        for (std::map<int, std::vector<cv::Point2f> >::const_iterator it = dr.corners.begin ();
+             it != dr.corners.end (); ++it)
+            ids_r.push_back (it->first);
+
+        if (shared.size () < 6) {
+            if (o.verbose)
+                printf ("  view %d: only %zu shared tags, skipped\n", index, shared.size ());
+            continue;
+        }
+        View v;
+        v.index = index;
+        v.base_T_flange = pose;
+        std::vector<cv::Point2f> tmp;
+        pack (dl, shared, v.obj, v.left);
+        pack (dr, shared, v.obj, v.right);      /* same obj, right-eye pixels */
+        pack (dl, ids_l, v.obj_l, v.img_l);
+        pack (dr, ids_r, v.obj_r, v.img_r);
+        views.push_back (v);
+        if (o.verbose)
+            printf ("  view %2d: %2zu/%2zu tags, %2zu shared -> %zu pairs\n",
+                    index, dl.corners.size (), dr.corners.size (), shared.size (),
+                    4 * shared.size ());
+    }
+    return views;
+}
+
+struct Fit {
+    cv::Mat K1, D1, K2, D2, R, T;
+    cv::Mat K1m, D1m, K2m, D2m;               /* the mono fits, before the stereo pass */
+    double rms_l, rms_r, rms_s;
+    std::vector<cv::Mat> rvecs, tvecs;        /* left-eye board poses, for hand-eye */
+};
+
+double solve_intrinsics (const std::vector<std::vector<cv::Point3f> > &objs,
+                         const std::vector<std::vector<cv::Point2f> > &imgs,
+                         cv::Size size, const char *label, bool verbose,
+                         cv::Mat &K, cv::Mat &D,
+                         std::vector<cv::Mat> &rvecs, std::vector<cv::Mat> &tvecs)
+{
+    const double rms = cv::calibrateCamera (objs, imgs, size, K, D, rvecs, tvecs,
+                                            DIST_MODEL_FLAG);
+    double worst = 0; size_t worst_i = 0, n = 0; double sum = 0;
+    for (size_t i = 0; i < objs.size (); i++) {
+        std::vector<cv::Point2f> proj;
+        cv::projectPoints (objs[i], rvecs[i], tvecs[i], K, D, proj);
+        double m = 0;
+        for (size_t j = 0; j < proj.size (); j++)
+            m += cv::norm (proj[j] - imgs[i][j]);
+        m /= (double) proj.size ();
+        sum += m; n++;
+        if (m > worst) { worst = m; worst_i = i; }
+    }
+    if (verbose)
+        printf ("  %s: RMS %.3f px, per-view mean %.3f (worst %.3f on view %zu)\n",
+                label, rms, sum / (double) n, worst, worst_i);
+    return rms;
+}
+
+bool run_fit (const std::vector<View> &vs, cv::Size size, const AgCalibSolveOpts &o, Fit &f)
+{
+    std::vector<std::vector<cv::Point3f> > ol, orr, os;
+    std::vector<std::vector<cv::Point2f> > il, ir, sl, sr;
+    for (size_t i = 0; i < vs.size (); i++) {
+        ol.push_back (vs[i].obj_l);  il.push_back (vs[i].img_l);
+        orr.push_back (vs[i].obj_r); ir.push_back (vs[i].img_r);
+        os.push_back (vs[i].obj);    sl.push_back (vs[i].left); sr.push_back (vs[i].right);
+    }
+    std::vector<cv::Mat> rv2, tv2;
+    f.rms_l = solve_intrinsics (ol, il, size, "left ", o.verbose, f.K1, f.D1, f.rvecs, f.tvecs);
+    f.rms_r = solve_intrinsics (orr, ir, size, "right", o.verbose, f.K2, f.D2, rv2, tv2);
+    f.K1m = f.K1.clone (); f.D1m = f.D1.clone ();
+    f.K2m = f.K2.clone (); f.D2m = f.D2.clone ();
+
+    const int flags = DIST_MODEL_FLAG | (o.refine_intrinsics ? cv::CALIB_USE_INTRINSIC_GUESS
+                                                             : cv::CALIB_FIX_INTRINSIC);
+    cv::Mat E, F;
+    f.rms_s = cv::stereoCalibrate (os, sl, sr, f.K1, f.D1, f.K2, f.D2, size,
+                                   f.R, f.T, E, F, flags,
+                                   cv::TermCriteria (cv::TermCriteria::EPS +
+                                                     cv::TermCriteria::MAX_ITER, 100, 1e-6));
+    return !f.R.empty () && !f.T.empty ();
+}
+
+/*
+ * Per-view reprojection RMS through the SINGLE fitted stereo model.
+ *
+ * Solve the board pose from the LEFT eye, carry it to the right through the common
+ * (R, T), and reproject into both. A view that does not conform to the one rigid
+ * baseline shows up here and nowhere else -- per-eye reprojection cannot see it,
+ * because each eye absorbs a relative rotation exactly into its own board pose.
+ *
+ * Same construction as the agrippa-stereocam calibration notebook's per-pair check.
+ */
+std::vector<double> per_view_stereo_rms (const std::vector<View> &vs, const Fit &f)
+{
+    std::vector<double> out;
+    cv::Matx33d R (f.R.at<double> (0,0), f.R.at<double> (0,1), f.R.at<double> (0,2),
+                   f.R.at<double> (1,0), f.R.at<double> (1,1), f.R.at<double> (1,2),
+                   f.R.at<double> (2,0), f.R.at<double> (2,1), f.R.at<double> (2,2));
+    cv::Vec3d T (f.T.at<double> (0), f.T.at<double> (1), f.T.at<double> (2));
+    for (size_t i = 0; i < vs.size (); i++) {
+        cv::Vec3d rl, tl;
+        if (!cv::solvePnP (vs[i].obj, vs[i].left, f.K1, f.D1, rl, tl)) {
+            out.push_back (std::numeric_limits<double>::infinity ());
+            continue;
+        }
+        cv::Matx33d Rl;
+        cv::Rodrigues (rl, Rl);
+        cv::Vec3d rr;
+        cv::Rodrigues (cv::Matx33d (R * Rl), rr);
+        const cv::Vec3d tr = R * tl + T;
+        std::vector<cv::Point2f> pl, pr;
+        cv::projectPoints (vs[i].obj, rl, tl, f.K1, f.D1, pl);
+        cv::projectPoints (vs[i].obj, rr, tr, f.K2, f.D2, pr);
+        double el = 0, er = 0;
+        for (size_t j = 0; j < pl.size (); j++) {
+            const double a = cv::norm (pl[j] - vs[i].left[j]);
+            const double b = cv::norm (pr[j] - vs[i].right[j]);
+            el += a * a; er += b * b;
+        }
+        el /= (double) pl.size (); er /= (double) pr.size ();
+        out.push_back (std::sqrt (0.5 * (el + er)));
+    }
+    return out;
+}
+
+/*
+ * How far apart the two eyes place the board, in mm.
+ *
+ * This is the number that says whether a hand-eye residual is the CAMERA's fault. The
+ * eyes are independent observers of the same rigid target, so their disagreement bounds
+ * the vision error. If the hand-eye spread is far larger than this, the residual lives
+ * in the robot's reported poses and no amount of extra views, extra distortion terms or
+ * fusing the second eye will touch it.
+ */
+void eye_agreement (const std::vector<View> &vs, const Fit &f, double *mean, double *worst)
+{
+    cv::Vec3d rvecR;
+    cv::Rodrigues (f.R, rvecR);
+    const cv::Matx44d left_T_right =
+        rt (rvecR, cv::Vec3d (f.T.at<double> (0), f.T.at<double> (1), f.T.at<double> (2))).inv ();
+    double sum = 0, mx = 0;
+    for (size_t i = 0; i < vs.size (); i++) {
+        cv::Vec3d rl, tl, rr, tr;
+        cv::solvePnP (vs[i].obj, vs[i].left,  f.K1, f.D1, rl, tl);
+        cv::solvePnP (vs[i].obj, vs[i].right, f.K2, f.D2, rr, tr);
+        const cv::Vec3d a = translation_of (rt (rl, tl));
+        const cv::Vec3d b = translation_of (left_T_right * rt (rr, tr));
+        const double gap = cv::norm (a - b) * 1000.0;
+        sum += gap;
+        mx = std::max (mx, gap);
+    }
+    *mean = sum / (double) vs.size ();
+    *worst = mx;
+}
+
+
+struct HandEye {
+    std::string name;
+    cv::Matx44d X;
+    double spread_mm;
+    double spread_deg;
+};
+
+/*
+ * flange_T_camera, plus the honest quality number: how much the implied board pose
+ * moves between views. The board did not move, so any spread is calibration error --
+ * and comparing it against the eye agreement says whether the residual is the camera's
+ * or the robot's.
+ */
+std::vector<HandEye> solve_hand_eye (const std::vector<View> &vs, const Fit &f)
+{
+    std::vector<cv::Mat> Rg, tg, Rc, tc;
+    for (size_t i = 0; i < vs.size (); i++) {
+        cv::Matx33d Rb;
+        for (int r = 0; r < 3; r++)
+            for (int c = 0; c < 3; c++) Rb(r, c) = vs[i].base_T_flange(r, c);
+        Rg.push_back (cv::Mat (Rb));
+        tg.push_back (cv::Mat (cv::Vec3d (vs[i].base_T_flange(0,3),
+                                          vs[i].base_T_flange(1,3),
+                                          vs[i].base_T_flange(2,3))));
+        cv::Matx33d Rcam;
+        cv::Rodrigues (f.rvecs[i], Rcam);
+        Rc.push_back (cv::Mat (Rcam));
+        cv::Mat t;
+        f.tvecs[i].convertTo (t, CV_64F);
+        tc.push_back (t.reshape (1, 3));
+    }
+
+    const char *names[4] = {"TSAI", "PARK", "HORAUD", "DANIILIDIS"};
+    const cv::HandEyeCalibrationMethod methods[4] = {
+        cv::CALIB_HAND_EYE_TSAI, cv::CALIB_HAND_EYE_PARK,
+        cv::CALIB_HAND_EYE_HORAUD, cv::CALIB_HAND_EYE_DANIILIDIS};
+
+    std::vector<HandEye> out;
+    for (int m = 0; m < 4; m++) {
+        cv::Mat R, t;
+        cv::calibrateHandEye (Rg, tg, Rc, tc, R, t, methods[m]);
+        if (R.empty () || t.empty ())
+            continue;
+        HandEye he;
+        he.name = names[m];
+        he.X = cv::Matx44d::eye ();
+        for (int r = 0; r < 3; r++) {
+            for (int c = 0; c < 3; c++) he.X(r, c) = R.at<double> (r, c);
+            he.X(r, 3) = t.at<double> (r);
+        }
+        /* Where each view says the board is. It never moved, so this should not move. */
+        std::vector<cv::Matx44d> boards;
+        cv::Vec3d mean (0, 0, 0);
+        for (size_t i = 0; i < vs.size (); i++) {
+            cv::Vec3d rv (f.rvecs[i].at<double> (0), f.rvecs[i].at<double> (1),
+                          f.rvecs[i].at<double> (2));
+            cv::Vec3d tv (f.tvecs[i].at<double> (0), f.tvecs[i].at<double> (1),
+                          f.tvecs[i].at<double> (2));
+            boards.push_back (vs[i].base_T_flange * he.X * rt (rv, tv));
+            mean += translation_of (boards.back ());
+        }
+        if (boards.empty ())
+            continue;
+        mean *= 1.0 / (double) boards.size ();
+        double spread = 0, ang = 0;
+        cv::Matx33d ref;
+        for (int r = 0; r < 3; r++)
+            for (int c = 0; c < 3; c++) ref(r, c) = boards[0](r, c);
+        for (size_t i = 0; i < boards.size (); i++) {
+            spread = std::max (spread, cv::norm (translation_of (boards[i]) - mean) * 1000.0);
+            cv::Matx33d Rb;
+            for (int r = 0; r < 3; r++)
+                for (int c = 0; c < 3; c++) Rb(r, c) = boards[i](r, c);
+            cv::Vec3d d;
+            cv::Rodrigues (cv::Matx33d (Rb * ref.t ()), d);
+            ang = std::max (ang, cv::norm (d) * 180.0 / CV_PI);
+        }
+        he.spread_mm = spread;
+        he.spread_deg = ang;
+        out.push_back (he);
+    }
+    return out;
+}
+
+}  // namespace
+
+int
+ag_calib_solve (const std::string &session_dir, const std::string &out_dir_in,
+                const AgCalibSolveOpts &o)
+{
+    const std::string out_dir = out_dir_in.empty () ? session_dir + "/calib_result" : out_dir_in;
+    const cv::Size size (o.eye_w, o.eye_h);
+
+    if (o.verbose) printf ("detecting:\n");
+    std::vector<View> views = load_views (session_dir, o);
+    if (views.size () < 4) {
+        fprintf (stderr, "only %zu usable views -- need more\n", views.size ());
+        return -1;
+    }
+    if (o.verbose) printf ("\n%zu views\n\nintrinsics:\n", views.size ());
+
+    Fit f;
+    if (!run_fit (views, size, o, f)) {
+        fprintf (stderr, "stereoCalibrate failed\n");
+        return -1;
+    }
+
+    /*
+     * Outlier pass. A view that does not conform to the ONE rigid baseline is invisible
+     * to per-eye reprojection (each eye absorbs a relative rotation into its own board
+     * pose) but drags the joint solve for everybody. Threshold and construction follow
+     * the agrippa-stereocam calibration notebook: max(2 x median, 1.0 px). Never drop
+     * below min_views, and always show the table.
+     */
+    size_t dropped = 0;
+    if (!o.keep_outliers) {
+        std::vector<double> rv = per_view_stereo_rms (views, f);
+        std::vector<double> sorted = rv;
+        std::sort (sorted.begin (), sorted.end ());
+        const double med = sorted[sorted.size () / 2];
+        const double thr = std::max (2.0 * med, 1.0);
+        std::vector<View> kept;
+        if (o.verbose)
+            printf ("\nper-view stereo conformity (median %.3f px, threshold %.3f px):\n",
+                    med, thr);
+        for (size_t i = 0; i < rv.size (); i++) {
+            const bool bad = rv[i] > thr;
+            if (o.verbose)
+                printf ("  view %2d  %7.3f px%s\n", views[i].index, rv[i],
+                        bad ? "   ** dropped **" : "");
+            if (!bad) kept.push_back (views[i]);
+        }
+        dropped = views.size () - kept.size ();
+        if (dropped && kept.size () >= (size_t) o.min_views) {
+            if (o.verbose)
+                printf ("  dropping %zu of %zu views, refitting on %zu\n",
+                        dropped, views.size (), kept.size ());
+            views.swap (kept);
+            if (!run_fit (views, size, o, f))
+                return -1;
+        } else if (dropped) {
+            if (o.verbose)
+                printf ("  %zu view(s) over threshold but only %zu would remain (min %d)"
+                        " -- keeping all\n", dropped, kept.size (), o.min_views);
+            dropped = 0;
+        } else if (o.verbose) {
+            printf ("  no outliers\n");
+        }
+    }
+
+    /*
+     * alpha is PINNED at 0 by default: the sweep deliberately leaves the
+     * gripper-occluded band under-constrained, and letting alpha auto-fit lets that
+     * extrapolated distortion drive the global ROI.
+     */
+    cv::Mat R1, R2, P1, P2, Q;
+    cv::stereoRectify (f.K1, f.D1, f.K2, f.D2, size, f.R, f.T, R1, R2, P1, P2, Q,
+                       cv::CALIB_ZERO_DISPARITY, o.alpha);
+
+    /* Mean |y_left - y_right| after rectification -- what a stereo matcher feels. */
+    std::vector<double> ep;
+    for (size_t i = 0; i < views.size (); i++) {
+        std::vector<cv::Point2f> ul, ur;
+        cv::undistortPoints (views[i].left,  ul, f.K1, f.D1, R1, P1);
+        cv::undistortPoints (views[i].right, ur, f.K2, f.D2, R2, P2);
+        for (size_t j = 0; j < ul.size (); j++)
+            ep.push_back (std::fabs (ul[j].y - ur[j].y));
+    }
+    std::sort (ep.begin (), ep.end ());
+    double ep_mean = 0;
+    for (size_t i = 0; i < ep.size (); i++) ep_mean += ep[i];
+    ep_mean /= (double) ep.size ();
+    const double ep_p95 = ep[(size_t) (0.95 * (double) (ep.size () - 1))];
+
+    double eye_mean = 0, eye_worst = 0;
+    eye_agreement (views, f, &eye_mean, &eye_worst);
+    const double baseline_mm = cv::norm (f.T) * 1000.0;
+
+    if (o.verbose) {
+        printf ("\nstereo:\n  RMS %.3f px, baseline %.2f mm\n", f.rms_s, baseline_mm);
+        printf ("  epipolar mean %.3f px (p95 %.3f)\n", ep_mean, ep_p95);
+        printf ("  eye agreement mean %.2f mm (worst %.2f)\n", eye_mean, eye_worst);
+    }
+
+    /* --- write the archive ------------------------------------------------------- */
+    mkdir (out_dir.c_str (), 0755);
+    const cv::Mat *arrays[8] = {&f.K1, &f.K2, &f.D1, &f.D2, &R1, &R2, &P1, &P2};
+    for (int i = 0; i < 8; i++) {
+        cv::Mat a;
+        arrays[i]->convertTo (a, CV_64F);
+        if (!a.isContinuous ()) a = a.clone ();
+        int shape[2] = {a.rows, a.cols};
+        char path[512];
+        snprintf (path, sizeof path, "%s/%s.npy", out_dir.c_str (), ARCHIVE_FILES[i]);
+        if (ag_npy_save (path, a.ptr<double> (), 2, shape) != 0)
+            return -1;
+    }
+
+    /*
+     * Hand-eye. The board never moved, so the spread of where each view PUTS it is the
+     * truth test; pick the method that minimises it. Compare against the eye agreement:
+     * a spread far above it means the residual is in the robot's reported flange poses,
+     * not in this calibration, and no amount of extra views will touch it.
+     */
+    std::vector<HandEye> he = solve_hand_eye (views, f);
+    size_t best = 0;
+    for (size_t i = 1; i < he.size (); i++)
+        if (he[i].spread_mm < he[best].spread_mm) best = i;
+    if (o.verbose) {
+        printf ("\nhand-eye (board spread is the truth test: the board never moved):\n");
+        for (size_t i = 0; i < he.size (); i++)
+            printf ("  %-11s t [%.1f, %.1f, %.1f] mm  board spread %6.2f mm / %5.2f deg%s\n",
+                    he[i].name.c_str (), he[i].X(0,3) * 1000, he[i].X(1,3) * 1000,
+                    he[i].X(2,3) * 1000, he[i].spread_mm, he[i].spread_deg,
+                    i == best ? "   <- best" : "");
+        if (!he.empty () && he[best].spread_mm > 5.0 * eye_mean)
+            printf ("  NOTE: spread %.2f mm is far above the %.2f mm the cameras disagree "
+                    "by -- the residual is in the robot's reported flange poses, not in "
+                    "the calibration.\n", he[best].spread_mm, eye_mean);
+    }
+
+    /*
+     * Key names here are a CONTRACT, not a style choice: publish.py reads hand_eye_best
+     * and hand_eye[best].flange_T_camera, and the backend store reads rms_stereo_px,
+     * mean_epipolar_error_px, baseline_cm (x10 -> baselineMm) and eye_agreement_mm.
+     * Renaming any of them makes the entry import with null metrics rather than fail.
+     */
+    cJSON *meta = cJSON_CreateObject ();
+
+    /* The controller's clock ran ~84 days behind until it was fixed, and the store
+     * needs a date that is actually right; publish.py prefers this field over a mtime,
+     * so an unsynced box would date every solve wrongly rather than obviously. */
+    time_t now = time (NULL);
+    struct tm g;
+    char stamp[32] = "";
+    if (gmtime_r (&now, &g))
+        strftime (stamp, sizeof stamp, "%Y-%m-%dT%H:%M:%SZ", &g);
+    cJSON_AddStringToObject (meta, "solved_at", stamp);
+
+    cJSON *isz = cJSON_AddArrayToObject (meta, "image_size");
+    cJSON_AddItemToArray (isz, cJSON_CreateNumber (o.eye_w));
+    cJSON_AddItemToArray (isz, cJSON_CreateNumber (o.eye_h));
+    cJSON_AddNumberToObject (meta, "num_pairs_used", (double) views.size ());
+    cJSON_AddNumberToObject (meta, "rms_stereo_px", f.rms_s);
+    cJSON_AddNumberToObject (meta, "mean_epipolar_error_px", ep_mean);
+    cJSON_AddNumberToObject (meta, "epipolar_p95_px", ep_p95);
+    cJSON_AddNumberToObject (meta, "rms_left_px", f.rms_l);
+    cJSON_AddNumberToObject (meta, "rms_right_px", f.rms_r);
+    cJSON_AddNumberToObject (meta, "baseline_cm", baseline_mm / 10.0);
+    cJSON_AddNumberToObject (meta, "focal_length_px", P1.at<double> (0, 0));
+    cJSON_AddNumberToObject (meta, "rectify_alpha", o.alpha);
+    cJSON_AddNumberToObject (meta, "views_dropped", (double) dropped);
+
+    cJSON *hej = cJSON_AddObjectToObject (meta, "hand_eye");
+    for (size_t i = 0; i < he.size (); i++) {
+        cJSON *e = cJSON_AddObjectToObject (hej, he[i].name.c_str ());
+        cJSON *ftc = cJSON_AddArrayToObject (e, "flange_T_camera");
+        cv::Matx33d R;
+        for (int r = 0; r < 3; r++)
+            for (int c = 0; c < 3; c++) R(r, c) = he[i].X(r, c);
+        cv::Vec3d rv;
+        cv::Rodrigues (R, rv);
+        for (int k = 0; k < 3; k++) cJSON_AddItemToArray (ftc, cJSON_CreateNumber (he[i].X(k, 3)));
+        for (int k = 0; k < 3; k++) cJSON_AddItemToArray (ftc, cJSON_CreateNumber (rv[k]));
+        cJSON_AddNumberToObject (e, "board_spread_mm", he[i].spread_mm);
+        cJSON_AddNumberToObject (e, "board_spread_deg", he[i].spread_deg);
+    }
+    if (!he.empty ())
+        cJSON_AddStringToObject (meta, "hand_eye_best", he[best].name.c_str ());
+
+    cJSON *ea = cJSON_AddObjectToObject (meta, "eye_agreement_mm");
+    cJSON_AddNumberToObject (ea, "mean", eye_mean);
+    cJSON_AddNumberToObject (ea, "max", eye_worst);
+
+    cJSON *bd = cJSON_AddObjectToObject (meta, "board");
+    cJSON_AddNumberToObject (bd, "columns", o.spec.columns);
+    cJSON_AddNumberToObject (bd, "rows", o.spec.rows);
+    cJSON_AddNumberToObject (bd, "tag_mm", o.spec.tag_mm);
+    cJSON_AddNumberToObject (bd, "gap_mm", o.spec.gap_mm);
+    cJSON_AddStringToObject (bd, "dictionary", "tag36h11");
+    cJSON_AddNumberToObject (bd, "border_cells", 2);
+
+    cJSON_AddStringToObject (meta, "solver", "ag-cam-tools calib-solve");
+    /* Which OpenCV solved this. The same session solved on a workstation and on the
+     * controller does NOT give bit-identical numbers -- the tag set comes out the same
+     * (70/70 on every eye of sweep_am either way, same single 69), but cornerSubPix and
+     * the calibrateCamera/stereoCalibrate optimisers changed between releases, and
+     * measured across 4.5.4 and 4.13 that moved the baseline by 0.22 mm (0.55%) and the
+     * stereo RMS by 0.006 px. Small, but it is a real physical quantity, so record what
+     * produced it rather than leaving the discrepancy to be rediscovered. */
+    cJSON_AddStringToObject (meta, "opencv_version", CV_VERSION);
+    cJSON_AddBoolToObject (meta, "intrinsics_refined_in_stereo", o.refine_intrinsics);
+
+    char *txt = cJSON_Print (meta);
+    char mpath[512];
+    snprintf (mpath, sizeof mpath, "%s/calibration_meta.json", out_dir.c_str ());
+    FILE *mf = fopen (mpath, "w");
+    int ok = mf && fputs (txt, mf) >= 0;
+    if (mf) ok = (fclose (mf) == 0) && ok;
+    free (txt);
+    cJSON_Delete (meta);
+    if (!ok) {
+        fprintf (stderr, "cannot write %s\n", mpath);
+        return -1;
+    }
+    if (o.verbose) printf ("\nwrote %s (8 .npy + calibration_meta.json)\n", out_dir.c_str ());
+    return 0;
+}
+
+#endif /* HAVE_OPENCV */

--- a/src/calib_solve.hpp
+++ b/src/calib_solve.hpp
@@ -1,0 +1,42 @@
+/*
+ * calib_solve.hpp — solve stereo intrinsics, extrinsics and hand-eye from a sweep.
+ *
+ * Consumes a session written by the on-robot capture RPC (planar Bayer view_NNN.raw
+ * plus a capture.jsonl carrying base_T_flange per view) and emits the calib_result/
+ * directory that `ag-cam-tools calibration-stash upload` packs into the camera.
+ *
+ * The output contract is fixed by the camera's own unpacker (calib_archive.c / npy.c):
+ * every array is little-endian float64 C-order, K 3x3, R 3x3, P 3x4, D 1xN. A float32
+ * array does not fail loudly there -- it parses as garbage -- which is why ag_npy_save
+ * has no dtype parameter.
+ *
+ * Ported from makeit-operate's makeit_operate/calibration/solve_stereo.py. OpenCV-only
+ * (HAVE_OPENCV), same as the grid detector it sits on.
+ */
+
+#ifndef AG_CALIB_SOLVE_HPP
+#define AG_CALIB_SOLVE_HPP
+
+#ifdef HAVE_OPENCV
+
+#include <string>
+#include "aprilgrid.hpp"
+
+struct AgCalibSolveOpts {
+    AgGridSpec spec;
+    int    eye_w = 1440;
+    int    eye_h = 1080;
+    double alpha = 0.0;          /* stereoRectify alpha; PINNED -- see the .cpp */
+    bool   keep_outliers = false;
+    bool   refine_intrinsics = false;
+    int    min_views = 8;
+    bool   verbose = true;
+};
+
+/* Solve `session_dir` into `out_dir` (default <session>/calib_result if empty).
+ * Returns 0 on success, -1 on failure (diagnostic on stderr). */
+int ag_calib_solve (const std::string &session_dir, const std::string &out_dir,
+                    const AgCalibSolveOpts &opts);
+
+#endif /* HAVE_OPENCV */
+#endif /* AG_CALIB_SOLVE_HPP */

--- a/src/calib_solve.hpp
+++ b/src/calib_solve.hpp
@@ -11,13 +11,13 @@
  * has no dtype parameter.
  *
  * Ported from makeit-operate's makeit_operate/calibration/solve_stereo.py. OpenCV-only
- * (HAVE_OPENCV), same as the grid detector it sits on.
+ * (HAVE_OPENCV_CALIB), same as the grid detector it sits on.
  */
 
 #ifndef AG_CALIB_SOLVE_HPP
 #define AG_CALIB_SOLVE_HPP
 
-#ifdef HAVE_OPENCV
+#ifdef HAVE_OPENCV_CALIB
 
 #include <string>
 #include "aprilgrid.hpp"
@@ -38,5 +38,5 @@ struct AgCalibSolveOpts {
 int ag_calib_solve (const std::string &session_dir, const std::string &out_dir,
                     const AgCalibSolveOpts &opts);
 
-#endif /* HAVE_OPENCV */
+#endif /* HAVE_OPENCV_CALIB */
 #endif /* AG_CALIB_SOLVE_HPP */

--- a/src/cmd_calib_solve.cpp
+++ b/src/cmd_calib_solve.cpp
@@ -5,7 +5,7 @@
  * will want it in-process) without dragging in argument parsing.
  */
 
-#ifdef HAVE_OPENCV
+#ifdef HAVE_OPENCV_CALIB
 
 #include "calib_solve.hpp"
 
@@ -54,4 +54,4 @@ cmd_calib_solve (int argc, char *argv[], arg_dstr_t res, void *ctx)
     return ag_calib_solve (session, out, o) == 0 ? 0 : 1;
 }
 
-#endif /* HAVE_OPENCV */
+#endif /* HAVE_OPENCV_CALIB */

--- a/src/cmd_calib_solve.cpp
+++ b/src/cmd_calib_solve.cpp
@@ -1,0 +1,57 @@
+/*
+ * cmd_calib_solve.cpp — `calib-solve` entry point.
+ *
+ * Separate TU from calib_solve.cpp so the solve is callable as a library (the backend
+ * will want it in-process) without dragging in argument parsing.
+ */
+
+#ifdef HAVE_OPENCV
+
+#include "calib_solve.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+extern "C" {
+#include "../vendor/argtable3.h"
+}
+
+extern "C" int cmd_calib_solve (int argc, char *argv[], arg_dstr_t res, void *ctx);
+
+int
+cmd_calib_solve (int argc, char *argv[], arg_dstr_t res, void *ctx)
+{
+    (void) res; (void) ctx;
+    AgCalibSolveOpts o;
+    const char *session = NULL, *out = "";
+    /* argtable3 hands the subcommand its own name in argv; depending on how it is
+     * invoked that lands at argv[0] or argv[1], so skip it wherever it is rather
+     * than assuming, or it gets consumed as the session path. */
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp (argv[i], "calib-solve")) continue;
+        if (!strcmp (argv[i], "--out") && i + 1 < argc)             out = argv[++i];
+        else if (!strcmp (argv[i], "--alpha") && i + 1 < argc)      o.alpha = atof (argv[++i]);
+        else if (!strcmp (argv[i], "--keep-outliers"))              o.keep_outliers = true;
+        else if (!strcmp (argv[i], "--refine-intrinsics"))          o.refine_intrinsics = true;
+        else if (!strcmp (argv[i], "--quiet"))                      o.verbose = false;
+        else if (!strcmp (argv[i], "--columns") && i + 1 < argc)    o.spec.columns = atoi (argv[++i]);
+        else if (!strcmp (argv[i], "--rows") && i + 1 < argc)       o.spec.rows = atoi (argv[++i]);
+        else if (!strcmp (argv[i], "--tag-mm") && i + 1 < argc)     o.spec.tag_mm = atof (argv[++i]);
+        else if (!strcmp (argv[i], "--gap-mm") && i + 1 < argc)     o.spec.gap_mm = atof (argv[++i]);
+        else if (argv[i][0] != '-' && !session)                     session = argv[i];
+        else {
+            fprintf (stderr, "usage: calib-solve <session> [--out DIR] [--alpha A]\n"
+                             "       [--keep-outliers] [--refine-intrinsics] [--quiet]\n"
+                             "       [--columns N] [--rows N] [--tag-mm MM] [--gap-mm MM]\n");
+            return 2;
+        }
+    }
+    if (!session) {
+        fprintf (stderr, "calib-solve: no session directory given\n");
+        return 2;
+    }
+    return ag_calib_solve (session, out, o) == 0 ? 0 : 1;
+}
+
+#endif /* HAVE_OPENCV */

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,9 @@ int cmd_depth_preview_neural (int argc, char *argv[], arg_dstr_t res, void *ctx)
 int cmd_calibration_stash (int argc, char *argv[], arg_dstr_t res, void *ctx);
 int cmd_depth_capture (int argc, char *argv[], arg_dstr_t res, void *ctx);
 int cmd_bounce (int argc, char *argv[], arg_dstr_t res, void *ctx);
+#ifdef HAVE_OPENCV
+int cmd_calib_solve (int argc, char *argv[], arg_dstr_t res, void *ctx);
+#endif
 
 static void
 print_usage (void)
@@ -46,6 +49,10 @@ print_usage (void)
             "  depth-capture\n"
             "            Capture RGBA depth map (RGB + depth alpha)\n"
             "  bounce    Reset (power-cycle) the camera over GigE\n"
+#ifdef HAVE_OPENCV
+            "  calib-solve\n"
+            "            Solve stereo + hand-eye from a captured sweep\n"
+#endif
             "\n"
             "Run 'ag-cam-tools <command> --help' for command-specific options.\n");
 }
@@ -79,6 +86,10 @@ main (int argc, char *argv[])
                       "Capture RGBA depth map (RGB + depth alpha)", NULL);
     arg_cmd_register ("bounce", cmd_bounce,
                       "Reset (power-cycle) the camera over GigE", NULL);
+#ifdef HAVE_OPENCV
+    arg_cmd_register ("calib-solve", cmd_calib_solve,
+                      "Solve stereo + hand-eye from a captured sweep", NULL);
+#endif
 
     if (argc < 2 ||
         strcmp (argv[1], "--help") == 0 ||

--- a/src/main.c
+++ b/src/main.c
@@ -20,7 +20,7 @@ int cmd_depth_preview_neural (int argc, char *argv[], arg_dstr_t res, void *ctx)
 int cmd_calibration_stash (int argc, char *argv[], arg_dstr_t res, void *ctx);
 int cmd_depth_capture (int argc, char *argv[], arg_dstr_t res, void *ctx);
 int cmd_bounce (int argc, char *argv[], arg_dstr_t res, void *ctx);
-#ifdef HAVE_OPENCV
+#ifdef HAVE_OPENCV_CALIB
 int cmd_calib_solve (int argc, char *argv[], arg_dstr_t res, void *ctx);
 #endif
 
@@ -49,7 +49,7 @@ print_usage (void)
             "  depth-capture\n"
             "            Capture RGBA depth map (RGB + depth alpha)\n"
             "  bounce    Reset (power-cycle) the camera over GigE\n"
-#ifdef HAVE_OPENCV
+#ifdef HAVE_OPENCV_CALIB
             "  calib-solve\n"
             "            Solve stereo + hand-eye from a captured sweep\n"
 #endif
@@ -86,7 +86,7 @@ main (int argc, char *argv[])
                       "Capture RGBA depth map (RGB + depth alpha)", NULL);
     arg_cmd_register ("bounce", cmd_bounce,
                       "Reset (power-cycle) the camera over GigE", NULL);
-#ifdef HAVE_OPENCV
+#ifdef HAVE_OPENCV_CALIB
     arg_cmd_register ("calib-solve", cmd_calib_solve,
                       "Solve stereo + hand-eye from a captured sweep", NULL);
 #endif

--- a/src/npy.c
+++ b/src/npy.c
@@ -2,7 +2,13 @@
  * npy.c — minimal NumPy .npy v1.0 parser for float64 arrays
  */
 
+/* memmem() is a GNU extension. BSD/macOS declares it in <string.h> unconditionally,
+ * glibc only under _GNU_SOURCE -- without which gcc implicitly declares it as
+ * returning int and truncates the pointer on 64-bit. Must precede every include. */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
+
 #include "npy.h"
 
 #include <stdio.h>
@@ -145,5 +151,74 @@ ag_npy_load (const uint8_t *buf, size_t len, AgNpyArray *out)
     for (int i = 0; i < ndim; i++)
         out->shape[i] = shape[i];
 
+    return 0;
+}
+
+/*
+ * Emit the ASCII header dict numpy itself writes, then the raw doubles.
+ *
+ * v1.0 requires the header be padded so that magic(6) + version(2) + len(2) + header
+ * is a multiple of 64, and that it end in '\n'. numpy also emits a trailing ", " before
+ * the closing brace and renders a 1-D shape as "(5,)" -- matched here so a file written
+ * by this and one written by numpy.save are byte-identical for the same array.
+ */
+int
+ag_npy_save (const char *path, const double *data, int ndim, const int *shape)
+{
+    if (!path || !data || !shape || ndim < 1 || ndim > 4) {
+        fprintf (stderr, "npy: bad arguments to ag_npy_save\n");
+        return -1;
+    }
+
+    char dims[64];
+    int  n = 0;
+    size_t count = 1;
+    for (int i = 0; i < ndim; i++) {
+        if (shape[i] < 0) {
+            fprintf (stderr, "npy: negative dimension %d\n", shape[i]);
+            return -1;
+        }
+        count *= (size_t) shape[i];
+        n += snprintf (dims + n, sizeof dims - (size_t) n, "%s%d",
+                       i ? ", " : "", shape[i]);
+        if (n < 0 || (size_t) n >= sizeof dims)
+            return -1;
+    }
+    if (ndim == 1)      /* numpy writes 1-D shapes as "(5,)" */
+        n += snprintf (dims + n, sizeof dims - (size_t) n, ",");
+
+    char header[256];
+    int hlen = snprintf (header, sizeof header,
+                         "{'descr': '<f8', 'fortran_order': False, 'shape': (%s), }", dims);
+    if (hlen < 0 || (size_t) hlen >= sizeof header)
+        return -1;
+
+    /* Pad with spaces so the whole preamble is 64-byte aligned, then newline. */
+    const int preamble = (int) sizeof k_npy_magic + 2;          /* magic+version, len field */
+    int total = preamble + hlen + 1;
+    int pad = (64 - (total % 64)) % 64;
+    if (hlen + pad + 1 >= (int) sizeof header)
+        return -1;
+    memset (header + hlen, ' ', (size_t) pad);
+    header[hlen + pad] = '\n';
+    const uint16_t header_len = (uint16_t) (hlen + pad + 1);
+
+    FILE *f = fopen (path, "wb");
+    if (!f) {
+        fprintf (stderr, "npy: cannot write %s\n", path);
+        return -1;
+    }
+    const uint8_t lenbytes[2] = { (uint8_t) (header_len & 0xff),
+                                  (uint8_t) (header_len >> 8) };   /* little-endian */
+    int ok = fwrite (k_npy_magic, 1, sizeof k_npy_magic, f) == sizeof k_npy_magic
+          && fwrite (lenbytes, 1, 2, f) == 2
+          && fwrite (header, 1, header_len, f) == header_len
+          && (count == 0 || fwrite (data, sizeof (double), count, f) == count);
+    if (fclose (f) != 0)
+        ok = 0;
+    if (!ok) {
+        fprintf (stderr, "npy: short write to %s\n", path);
+        return -1;
+    }
     return 0;
 }

--- a/src/npy.h
+++ b/src/npy.h
@@ -27,4 +27,18 @@ typedef struct {
  */
 int ag_npy_load (const uint8_t *buf, size_t len, AgNpyArray *out);
 
+/*
+ * Write a float64 C-order .npy v1.0 file.
+ *
+ * The counterpart to ag_npy_load, and deliberately just as narrow: the camera's
+ * calibration slot only ever carries '<f8' C-order arrays of 1 or 2 dimensions
+ * (K 3x3, R 3x3, P 3x4, D 1xN), and ag_npy_load rejects anything else. Emitting a
+ * float32 array would not fail loudly -- it parses as garbage -- so there is no
+ * dtype parameter to get wrong.
+ *
+ * `shape` has `ndim` entries; data is ndim-many dimensions' product of doubles,
+ * C-order. Returns 0 on success, -1 on error (diagnostic on stderr).
+ */
+int ag_npy_save (const char *path, const double *data, int ndim, const int *shape);
+
 #endif /* AG_NPY_H */


### PR DESCRIPTION
Adds AprilGrid target detection and a `calib-solve` subcommand, so a captured sweep can be
solved into `calib_result/` on the controller instead of on a laptop. Five commits, each
of which builds; the last is a `.gitignore` for bench artefacts and is independent.

## What and why

**Border-2 tag family.** calib.io and Kalibr print AprilGrid targets with a two-cell black
border. apriltag3 assumes one cell, so it locates the quad on the wrong boundary and
decodes *zero* tags off an otherwise perfect board. `tag36h11b2` copies tag36h11 and
shifts `width_at_border`, `total_width` and every `bit_x/bit_y` by a cell; the code table
is untouched, so the two families share ids exactly (0 of 587 differ). The family list
also becomes a table, so a caller registers only what it uses — every registered family is
decoded against on every quad, and the tables run to 65k codes.

**Whole-board detection.** Knowing the board means a tag the seed pass missed is predicted
from its neighbours and verified against its own bit pattern instead of lost — 21-49 tags
a frame becomes all 70, and the ones a plain pass drops are the oblique, dim, frame-edge
tags carrying most of the distortion signal.

**`calib-solve`.** Per-eye intrinsics, stereo with intrinsics fixed, per-view outlier
rejection, rectify, hand-eye. `ag_npy_save` is the write half of `ag_npy_load`, which
could only read; K/D/R/P travel as `.npy`, which is the interchange format `calib_archive.c`
already uses. The distortion *map* is still computed at runtime by `ag_remap_from_calib`.

## No opencv_contrib

The detector deliberately does not use ArUco. It would do the seed pass, but on the OpenCV
Ubuntu 22.04 packages ArUco lives in `opencv_contrib`, and contrib drags GDAL, GTK-3, x265
and GDCM — 279 packages, +314 MB — for one adaptive-threshold-and-decode. Without it the
three modules needed (`core`, `imgproc`, `calib3d`) are stock apt packages, +11 MB.

`HAVE_OPENCV` keeps its existing meaning everywhere it is already tested (the SGBM depth
backend) and is now gated on the `ximgproc` header actually being present; `HAVE_OPENCV_CALIB`
is new and covers the solver. So an OpenCV without contrib builds fine and still gets
`calib-solve`, it just does not get the depth backend.

libapriltag's *detector* is also unused, which is not an oversight: it finds the quads and
decodes almost none at the ~3.5 px/cell this board lands at — 27-34 quads a frame for 0-11
decodes, exactly zero on 7 of 11 frames including clean fronto-parallel ones. quad_sigma,
decode_sharpening, min_white_black_diff, min_cluster_pixels and 2x upsampling each made it
worse. Its tag36h11 *code table* is used, which is the part that is unambiguous.

## Verification

Validated against the Python implementation this was ported from, on real captured sessions.

| check | result |
|---|---|
| detection, 22 eyes of one sweep | identical seed/guided/total counts, incl. the one frame yielding 69 |
| detection, 84 eyes over six sessions | same tag set on 83; 5712 shared corners agree to a median of 0.000047 px |
| solve, `sweep_am` | same outlier view dropped, same 10 of 11 kept; RMS 0.310 px, baseline 39.92 mm, epipolar 0.408 px, eye agreement 0.57 mm |
| K / rectification rotations | 3e-7 relative / 0.00 arcsec |
| functional (60x45 grid through both models) | median 0.003 px, max 0.017 px — ~100x under the stereo RMS |
| three further sessions | agree to 3-4 significant figures, same best hand-eye method |
| `ag_npy_save` | byte-identical to `numpy.save` for 3x3, 3x4, (8,) and (1,8) |
| every commit | `make bin/ag-cam-tools` succeeds |
| linux/amd64, no contrib | full `make` succeeds incl. `libagrippa.so`; SGBM correctly skipped |

## Notes for review

- The Makefile hunk switching the vendored apriltag build to `$(wildcard tag*.c)` is in the
  first commit, not a later one — the family table names seven more families, so without it
  the link fails on `_tag36h11_create`.
- `npy.c` keeps main's `_GNU_SOURCE` fix and only wraps it in `#ifndef` plus a note on why
  it must precede the includes. That fix and `npy.h`'s `<stdint.h>` were already made on
  main independently; nothing here re-fixes them.
- Unrelated, but noticed while testing: `make` fails on macOS at `bin/libagrippa.so` with
  `ld: unknown options: -soname`. That is GNU ld syntax; Apple's ld wants `-install_name`.
  Pre-existing on `main`, not touched here.